### PR TITLE
feat: register own resource GVK at service provider

### DIFF
--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -31,7 +31,10 @@ import (
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
 	"github.com/openmcp-project/openmcp-operator/api/common"
 	openmcpconst "github.com/openmcp-project/openmcp-operator/api/constants"
+	providerv1alpha1 "github.com/openmcp-project/openmcp-operator/api/provider/v1alpha1"
 	"github.com/openmcp-project/openmcp-operator/lib/clusteraccess"
+	"github.com/openmcp-project/openmcp-operator/lib/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openmcp-project/service-provider-template/api/crds"
 	// spruntime "github.com/openmcp-project/service-provider-template/pkg/runtime"
@@ -73,6 +76,7 @@ func initPlatformScheme() {
 	utilruntime.Must(apiextensionv1.AddToScheme(platformScheme))
 	utilruntime.Must({{.KindLower}}sv1alpha1.AddToScheme(platformScheme))
 	utilruntime.Must(clustersv1alpha1.AddToScheme(platformScheme))
+	utilruntime.Must(providerv1alpha1.AddToScheme(platformScheme))
 }
 
 func initOnboardingScheme() {
@@ -88,6 +92,8 @@ func initMcpScheme() {
 
 // nolint:gocyclo
 func main() {
+	var command string
+	var environment, providerName, verbosity string
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
@@ -96,6 +102,9 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
+    flag.StringVar(&environment, "environment", "", "Name of the environment")
+    flag.StringVar(&providerName, "provider-name", "", "Name of the provider resource")
+    flag.StringVar(&verbosity, "verbosity", "", "Verbosity level for logging")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -116,6 +125,13 @@ func main() {
 	opts := zap.Options{
 		Development: true,
 	}
+
+    // extract command from os.Args if present to allow further flag parsing
+    if len(os.Args) > 1 {
+        command = os.Args[1]
+        os.Args = append([]string{os.Args[0]}, os.Args[2:]...)
+    }
+
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -220,7 +236,7 @@ func main() {
 		WithTimeout(30 * time.Minute)
 	ctx := context.Background()
 	// init (job that installs CRDs)
-	if os.Args[1] == "init" {
+	if command == "init" {
 		onboardingCluster, err := clusterAccessManager.CreateAndWaitForCluster(ctx, "onboarding-init",
 			clustersv1alpha1.PURPOSE_ONBOARDING, onboardingScheme, adminPermissions)
 
@@ -236,6 +252,17 @@ func main() {
 		if err := crdManager.CreateOrUpdateCRDs(ctx, &log); err != nil {
 			setupLog.Error(err, "Failed to create or update CRDs")
 		}
+
+		spGVK := metav1.GroupVersionKind{
+			Group:   {{.KindLower}}sv1alpha1.GroupVersion.Group,
+			Version: {{.KindLower}}sv1alpha1.GroupVersion.Version,
+			Kind:    "{{.Kind}}",
+		}
+		if err := utils.RegisterGVKsAtServiceProvider(ctx, platformCluster.Client(), providerName, spGVK); err != nil {
+			setupLog.Error(err, "Failed to register GVK at ServiceProvider")
+			return
+		}
+
 		return
 	}
 	// run (sp controller deployment)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the registration of the GVK at the service provider to the template. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/service-provider-template/issues/5

**Special notes for your reviewer**:
You may wonder (or maybe you're already familiar with this behaviour) why I had to add [this](https://github.com/openmcp-project/service-provider-template/pull/7/files#diff-6a7aff441ae426770641fdf4484cf0d36616b7283ada48b9b682db0cdb0480bbR128-R134). Otherwise flags coming after `init` (or `run`) wouldn't be parsed, as `flags.Parse` stops parsing after the first flag that does _not_ start with a `-` (see: [
Parse()](https://cs.opensource.google/go/go/+/refs/tags/go1.25.5:src/flag/flag.go;l=1153-1177) and [parseOne()](https://cs.opensource.google/go/go/+/refs/tags/go1.25.5:src/flag/flag.go;l=1074-1107)). Therefore, extracting the `init|run` subcommand before we call `flags.Parse()`. As a matter of fact, none of the existing params has been parsed before, too. 

I suggest we refactor this to `Cobra` soon. For now (as we said we won't cobra right now), I stick to this workaround.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Register own GVK as resource at serviceprovider
```

On-behalf-of: Radek Schekalla (SAP) <radek.schekalla@sap.com>
