### PR TITLE
fix: panic if access request is nil

### DIFF
--- a/pkg/runtime/spreconciler.go
+++ b/pkg/runtime/spreconciler.go
@@ -250,7 +250,7 @@ func (r *SPReconciler[T, PC]) createOrUpdate(ctx context.Context, obj T, pc PC) 
 // It is used to prevent renewing cluster access when deleting an ServiceProviderAPI object.
 func (r *SPReconciler[T, PC]) areAccessRequestsInDeletion(ctx context.Context, req ctrl.Request) (bool, error) {
 	accessRequest, err := r.clusterAccessReconciler.MCPAccessRequest(ctx, req)
-	if apierrors.IsNotFound(err) || accessRequest.DeletionTimestamp != nil {
+	if apierrors.IsNotFound(err) || (accessRequest != nil && accessRequest.DeletionTimestamp != nil) {
 		return true, nil
 	}
 	if err != nil {
@@ -258,7 +258,7 @@ func (r *SPReconciler[T, PC]) areAccessRequestsInDeletion(ctx context.Context, r
 	}
 	if r.withWorkloadCluster {
 		accessRequest, err = r.clusterAccessReconciler.WorkloadAccessRequest(ctx, req)
-		if apierrors.IsNotFound(err) || accessRequest.DeletionTimestamp != nil {
+		if apierrors.IsNotFound(err) || (accessRequest != nil && accessRequest.DeletionTimestamp != nil) {
 			return true, nil
 		}
 		if err != nil {


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Fixes panic if access request is nil.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
