### PR TITLE
feat: Add support for optional secret watcher.

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate template
         run: |
-          go run ./cmd/template -v -w
+          go run ./cmd/template -v -w -s
 
       - name: task generate
         run: |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The template generator (`cmd/template`) supports the following flags:
 - `-group`: GVK group prefix, will be suffixed with `services.openmcp.cloud` (default: `foo`)
 - `-v`: Generate with sample code (default: `false`)
 - `-w`: Generate a service provider that reconciles its `DomainServiceAPI` on the [WorkloadCluster](https://openmcp-project.github.io/docs/about/design/service-provider#deployment-model) (default: `false`)
+- `-s`: Generate secret watcher implementation (default: `false`)
 
 ### Service Provider Runtime Flags
 

--- a/cmd/template/files/controller.go.tmpl
+++ b/cmd/template/files/controller.go.tmpl
@@ -22,6 +22,10 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
+	{{- if .WithSecretWatcher }}
+	corev1 "k8s.io/api/core/v1"
+	{{- end }}
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -92,6 +96,8 @@ func (r *{{.Kind}}Reconciler) Delete(ctx context.Context, obj *apiv1alpha1.{{.Ki
 {{- if .WithSecretWatcher }}
 // IsReferencedSecret returns true if the given secret should trigger
 // reconciliation. See spruntime.SecretWatcher for details.
+//
+//revive:disable:unused-parameter
 func (r *{{.Kind}}Reconciler) IsReferencedSecret(ctx context.Context, secret *corev1.Secret, pc *apiv1alpha1.ProviderConfig) bool {
 	if pc == nil {
 		return false

--- a/cmd/template/files/controller.go.tmpl
+++ b/cmd/template/files/controller.go.tmpl
@@ -88,6 +88,23 @@ func (r *{{.Kind}}Reconciler) Delete(ctx context.Context, obj *apiv1alpha1.{{.Ki
 	return ctrl.Result{}, nil
 {{- end }}
 }
+
+{{- if .WithSecretWatcher }}
+// IsReferencedSecret returns true if the given secret should trigger
+// reconciliation. See spruntime.SecretWatcher for details.
+func (r *{{.Kind}}Reconciler) IsReferencedSecret(ctx context.Context, secret *corev1.Secret, pc *apiv1alpha1.ProviderConfig) bool {
+	if pc == nil {
+		return false
+	}
+	// TODO: Check if the secret is referenced in the provider config, for example:
+	// for _, ref := range pc.Spec.ImagePullSecrets {
+	//     if ref.Name == secret.Name {
+	//         return true
+	//     }
+	// }
+	return false
+}
+{{- end }}
 {{ if .WithExample }}
 func fooCRD() *apiextensionsv1.CustomResourceDefinition {
 	return &apiextensionsv1.CustomResourceDefinition{

--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -319,6 +319,9 @@ func main() {
 	).
 		WithPlatformCluster(platformCluster).
 		WithOnboardingCluster(onboardingCluster).
+		{{- if .WithSecretWatcher }}
+		WithSecretNamespace(podNamespace).
+		{{- end }}
 		WithServiceProviderReconciler(&controller.{{.Kind}}Reconciler{
 			OnboardingCluster: onboardingCluster,
 			PlatformCluster:   platformCluster,

--- a/cmd/template/main.go
+++ b/cmd/template/main.go
@@ -28,6 +28,7 @@ type TemplateData struct {
 	RepoName            string
 	WithExample         bool
 	WithWorkloadCluster bool
+	WithSecretWatcher   bool
 }
 
 //nolint:gocyclo
@@ -36,6 +37,7 @@ func main() {
 	kind := flag.String("kind", "FooService", "GVK kind")
 	withExample := flag.Bool("v", false, "Generate with sample code")
 	withWorkloadCluster := flag.Bool("w", false, "Reconcile with workload cluster")
+	withSecretWatcher := flag.Bool("s", false, "Generate secret watcher implementation")
 	module := flag.String("module", "github.com/openmcp-project/service-provider-template", "Go module")
 	flag.Parse()
 	data := TemplateData{
@@ -46,6 +48,7 @@ func main() {
 		RepoName:            filepath.Base(*module),
 		WithExample:         *withExample,
 		WithWorkloadCluster: *withWorkloadCluster,
+		WithSecretWatcher:   *withSecretWatcher,
 	}
 	// directories
 	apiDir := filepath.Join("api", "v1alpha1")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/openmcp-project/controller-utils v0.23.4
 	github.com/openmcp-project/openmcp-operator/api v0.17.1
 	github.com/stretchr/testify v1.11.1
+	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
 	sigs.k8s.io/controller-runtime v0.22.4
@@ -33,7 +34,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/vladimirvivien/gexe v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.35.0 // indirect
 	sigs.k8s.io/kind v0.31.0 // indirect
 )
 

--- a/pkg/spruntime/spreconciler.go
+++ b/pkg/spruntime/spreconciler.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
+	controllerutil2 "github.com/openmcp-project/controller-utils/pkg/controller"
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -28,6 +31,19 @@ type ServiceProviderReconciler[T ServiceProviderAPI, PC ProviderConfig] interfac
 	CreateOrUpdate(ctx context.Context, obj T, pc PC, clusters ClusterContext) (ctrl.Result, error)
 	// Delete is called on every delete event
 	Delete(ctx context.Context, obj T, pc PC, clusters ClusterContext) (ctrl.Result, error)
+}
+
+// SecretWatcher can optionally be implemented by a ServiceProviderReconciler
+// to trigger reconciliation of all ServiceProviderAPI objects when a
+// referenced secret in the provider namespace changes.
+// The watch is set up on the platform cluster and filtered to the namespace
+// configured via WithSecretNamespace.
+type SecretWatcher[PC ProviderConfig] interface {
+	// IsReferencedSecret returns true if the given secret should trigger
+	// reconciliation. pc is the current provider config — it will be the
+	// zero value (nil for pointer types) if not yet loaded; implementations
+	// must guard against this.
+	IsReferencedSecret(ctx context.Context, secret *corev1.Secret, pc PC) bool
 }
 
 // ClusterContext provides access to request-scoped clusters.
@@ -120,6 +136,8 @@ type SPReconciler[T ServiceProviderAPI, PC ProviderConfig] struct {
 	providerConfig atomic.Pointer[PC]
 	// withWorkloadCluster defines whether a service provider requires access to a workload cluster
 	withWorkloadCluster bool
+	// secretNamespace is the namespace to watch secrets in on the platform cluster. Used only if the ServiceProviderReconciler also implements SecretWatcher.
+	secretNamespace string
 	// emptyObj creates an empty object of the api type
 	emptyObj func() T
 }
@@ -158,6 +176,12 @@ func (r *SPReconciler[T, PC]) WithServiceProviderReconciler(dsr ServiceProviderR
 // WithWorkloadCluster sets if the service provider reconciler requests a workload cluster
 func (r *SPReconciler[T, PC]) WithWorkloadCluster(b bool) *SPReconciler[T, PC] {
 	r.withWorkloadCluster = b
+	return r
+}
+
+// WithSecretNamespace enables secret watching in the given namespace on the platform cluster. Only used if the ServiceProviderReconciler also implements SecretWatcher.
+func (r *SPReconciler[T, PC]) WithSecretNamespace(ns string) *SPReconciler[T, PC] {
+	r.secretNamespace = ns
 	return r
 }
 
@@ -354,7 +378,7 @@ func (r *SPReconciler[T, PC]) clusters(ctx context.Context, req ctrl.Request) (C
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SPReconciler[T, PC]) SetupWithManager(mgr ctrl.Manager, name string, providerConfigUpdates chan event.GenericEvent) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	controller := ctrl.NewControllerManagedBy(mgr).
 		For(r.emptyObj()).
 		// sets up reconciles whenever provider config controller sends update events
 		WatchesRawSource(
@@ -370,24 +394,61 @@ func (r *SPReconciler[T, PC]) SetupWithManager(mgr ctrl.Manager, name string, pr
 							r.providerConfig.Store(nil)
 						}
 						// reconcile all existing objects
-						var list unstructured.UnstructuredList
-						gvk := r.emptyObj().GetObjectKind().GroupVersionKind()
-						list.SetGroupVersionKind(gvk)
-						if err := r.onboardingCluster.Client().List(ctx, &list); err != nil {
-							return nil
-						}
-						reqs := make([]reconcile.Request, len(list.Items))
-						for i := range list.Items {
-							reqs[i] = reconcile.Request{
-								NamespacedName: client.ObjectKeyFromObject(&list.Items[i]),
-							}
-						}
-						return reqs
+						return r.enqueueAllObjects(ctx)
 					},
 				)),
-		).
-		Named(name).
-		Complete(r)
+		)
+
+	// Optional: watch secrets on the platform cluster if the reconciler implements SecretWatcher
+	if sw, ok := r.serviceProviderReconciler.(SecretWatcher[PC]); ok && r.secretNamespace != "" {
+		controller = controller.WatchesRawSource(
+			source.Kind(
+				r.platformCluster.Cluster().GetCache(),
+				&corev1.Secret{},
+				handler.TypedEnqueueRequestsFromMapFunc(r.mapSecretToRequests(sw)),
+				controllerutil2.ToTypedPredicate[*corev1.Secret](
+					predicate.NewPredicateFuncs(func(obj client.Object) bool {
+						return obj.GetNamespace() == r.secretNamespace
+					}),
+				),
+			),
+		)
+	}
+
+	return controller.Named(name).Complete(r)
+}
+
+// mapSecretToRequests returns a typed map function that checks whether a changed secret
+// is referenced by the service provider and, if so, enqueues all ServiceProviderAPI objects.
+func (r *SPReconciler[T, PC]) mapSecretToRequests(sw SecretWatcher[PC]) func(ctx context.Context, secret *corev1.Secret) []reconcile.Request {
+	return func(ctx context.Context, secret *corev1.Secret) []reconcile.Request {
+		var pcVal PC
+		if pc := r.providerConfig.Load(); pc != nil {
+			pcVal = *pc
+		}
+		if !sw.IsReferencedSecret(ctx, secret, pcVal) {
+			return nil
+		}
+		return r.enqueueAllObjects(ctx)
+	}
+}
+
+// enqueueAllObjects lists all ServiceProviderAPI objects and returns a reconcile request for each.
+func (r *SPReconciler[T, PC]) enqueueAllObjects(ctx context.Context) []reconcile.Request {
+	var list unstructured.UnstructuredList
+	gvk := r.emptyObj().GetObjectKind().GroupVersionKind()
+	list.SetGroupVersionKind(gvk)
+	if err := r.onboardingCluster.Client().List(ctx, &list); err != nil {
+		logf.FromContext(ctx).Error(err, "failed to list objects")
+		return nil
+	}
+	reqs := make([]reconcile.Request, len(list.Items))
+	for i := range list.Items {
+		reqs[i] = reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(&list.Items[i]),
+		}
+	}
+	return reqs
 }
 
 func retrieveSecretKey(ar *clustersv1alpha1.AccessRequest) client.ObjectKey {

--- a/pkg/spruntime/spreconciler_test.go
+++ b/pkg/spruntime/spreconciler_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,6 +23,7 @@ import (
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 const (
@@ -266,16 +269,15 @@ func (f FakeClusterAccessProvider) WorkloadCluster(ctx context.Context, request 
 	return f.Workload, nil
 }
 
+var testGV = schema.GroupVersion{Group: "openmcp.test", Version: "v1"}
+
 func createFakeCluster(t *testing.T, id string, clusterObjects ...client.Object) *clusters.Cluster {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = apiextv1.AddToScheme(scheme)
 	_ = clustersv1alpha1.AddToScheme(scheme)
-	scheme.AddKnownTypes(schema.GroupVersion{
-		Group:   "openmcp.test",
-		Version: "v1",
-	}, &fakeApiImpl{}, &fakeProviderConfigImpl{})
+	scheme.AddKnownTypes(testGV, &fakeApiImpl{}, &fakeProviderConfigImpl{})
 
 	// init cluster with objects
 	fakeClient := fake.NewClientBuilder().WithObjects(clusterObjects...).WithScheme(scheme).Build()
@@ -325,4 +327,138 @@ func (f *fakeProviderConfigImpl) DeepCopyObject() runtime.Object {
 
 func (f *fakeProviderConfigImpl) PollInterval() time.Duration {
 	return f.FakePollInterval
+}
+
+// MockSecretWatchingReconciler satisfies both ServiceProviderReconciler and SecretWatcher.
+type MockSecretWatchingReconciler struct {
+	MockServiceProviderReconciler
+	referencedSecrets map[string]bool
+}
+
+var _ SecretWatcher[*fakeProviderConfigImpl] = &MockSecretWatchingReconciler{}
+
+func (m *MockSecretWatchingReconciler) IsReferencedSecret(_ context.Context, secret *corev1.Secret, _ *fakeProviderConfigImpl) bool {
+	return m.referencedSecrets[secret.Name]
+}
+
+// createFakeClusterWithUnstructuredList creates a fake cluster whose client supports
+// listing unstructured objects by intercepting List calls and populating the result
+// from the given objects.
+func createFakeClusterWithUnstructuredList(t *testing.T, id string, objs []client.Object) *clusters.Cluster {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	scheme.AddKnownTypes(testGV, &fakeApiImpl{}, &fakeProviderConfigImpl{})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if ul, ok := list.(*unstructured.UnstructuredList); ok {
+					for _, obj := range objs {
+						u := unstructured.Unstructured{}
+						u.SetName(obj.GetName())
+						u.SetNamespace(obj.GetNamespace())
+						ul.Items = append(ul.Items, u)
+					}
+					return nil
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	return clusters.NewTestClusterFromClient(id, fakeClient)
+}
+
+func TestMapSecretToRequests(t *testing.T) {
+	tests := []struct {
+		name           string
+		secret         *corev1.Secret
+		referenced     map[string]bool
+		providerConfig *fakeProviderConfigImpl
+		existingObjs   []client.Object
+		wantRequests   int
+	}{
+		{
+			name: "referenced secret with existing objects triggers reconciliation",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: testNamespaceName},
+			},
+			referenced:     map[string]bool{"my-secret": true},
+			providerConfig: &fakeProviderConfigImpl{FakePollInterval: time.Hour},
+			existingObjs: []client.Object{
+				&fakeApiImpl{ObjectMeta: metav1.ObjectMeta{Name: "obj-1", Namespace: testNamespaceName}},
+				&fakeApiImpl{ObjectMeta: metav1.ObjectMeta{Name: "obj-2", Namespace: testNamespaceName}},
+			},
+			wantRequests: 2,
+		},
+		{
+			name: "unreferenced secret does not trigger reconciliation",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: testNamespaceName},
+			},
+			referenced:     map[string]bool{"my-secret": true},
+			providerConfig: &fakeProviderConfigImpl{FakePollInterval: time.Hour},
+			existingObjs: []client.Object{
+				&fakeApiImpl{ObjectMeta: metav1.ObjectMeta{Name: "obj-1", Namespace: testNamespaceName}},
+			},
+			wantRequests: 0,
+		},
+		{
+			name: "referenced secret with no existing objects returns empty",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: testNamespaceName},
+			},
+			referenced:     map[string]bool{"my-secret": true},
+			providerConfig: &fakeProviderConfigImpl{FakePollInterval: time.Hour},
+			existingObjs:   nil,
+			wantRequests:   0,
+		},
+		{
+			name: "nil provider config does not panic",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: testNamespaceName},
+			},
+			referenced:     map[string]bool{"my-secret": true},
+			providerConfig: nil,
+			existingObjs:   nil,
+			wantRequests:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			onboardingCluster := createFakeClusterWithUnstructuredList(t, "onboarding", tt.existingObjs)
+
+			mockSW := &MockSecretWatchingReconciler{
+				referencedSecrets: tt.referenced,
+			}
+
+			r := NewSPReconciler[*fakeApiImpl, *fakeProviderConfigImpl](func() *fakeApiImpl {
+				obj := &fakeApiImpl{}
+				obj.SetGroupVersionKind(testGV.WithKind("fakeApiImpl"))
+				return obj
+			}).
+				WithOnboardingCluster(onboardingCluster).
+				WithServiceProviderReconciler(mockSW)
+
+			if tt.providerConfig != nil {
+				r.WithProviderConfig(tt.providerConfig)
+			}
+
+			mapFn := r.mapSecretToRequests(mockSW)
+			reqs := mapFn(context.Background(), tt.secret)
+			assert.Equal(t, tt.wantRequests, len(reqs))
+
+			if tt.wantRequests > 0 {
+				names := make(map[string]bool)
+				for _, req := range reqs {
+					names[req.Name] = true
+				}
+				for _, obj := range tt.existingObjs {
+					assert.True(t, names[obj.GetName()], "expected request for object %s", obj.GetName())
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, different service providers have sligtly different implementations of a secret watching mechanism to sync secrets between clusters. This PR implementats a common pattern to watch secrets on the platform cluster and trigger reconciliation of all service provider resources when a referenced secret changes. This is an optional feature.

**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/backlog/issues/512

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added an optional, generic SecretWatcher interface to the spruntime to allow secrets watching and syncing.
```
