### PR TITLE
chore: dynamically read e2e image version from VERSION file

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,6 +7,7 @@ vars:
   CODE_DIRS: '{{.ROOT_DIR}}/cmd/... {{.ROOT_DIR}}/internal/... {{.ROOT_DIR}}/api/v1alpha1/... {{.ROOT_DIR}}/pkg/...'
   COMPONENTS: 'service-provider-template'
   REPO_URL: 'https://github.com/openmcp-project/service-provider-template'
+  COMMON_SCRIPT_DIR: '{{.ROOT_DIR}}/hack/common'
 
 includes:
   shared:
@@ -21,7 +22,7 @@ tasks:
       - docker tag ghcr.io/openmcp-project/images/{{.COMPONENTS}}:{{.VERSION}}-linux-{{ARCH}} ghcr.io/openmcp-project/images/{{.COMPONENTS}}:{{.VERSION}}
     vars:
       VERSION:
-        sh: cat VERSION
+        sh: $COMMON_SCRIPT_DIR/get-version.sh
       ARCH:
         sh: uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'
 

--- a/cmd/template/files/Taskfile.yaml.tmpl
+++ b/cmd/template/files/Taskfile.yaml.tmpl
@@ -7,7 +7,7 @@ vars:
   CODE_DIRS: '{{"{{"}}.ROOT_DIR{{"}}"}}/cmd/... {{"{{"}}.ROOT_DIR{{"}}"}}/internal/... {{"{{"}}.ROOT_DIR{{"}}"}}/api/v1alpha1/... {{"{{"}}.ROOT_DIR{{"}}"}}/pkg/...'
   COMPONENTS: '{{.RepoName}}'
   REPO_URL: 'https://{{.Module}}'
-  COMMON_SCRIPT_DIR: '{{.ROOT_DIR}}/hack/common'
+  COMMON_SCRIPT_DIR: '{{"{{"}}.ROOT_DIR{{"}}"}}/hack/common'
 
 includes:
   shared:

--- a/cmd/template/files/Taskfile.yaml.tmpl
+++ b/cmd/template/files/Taskfile.yaml.tmpl
@@ -7,6 +7,7 @@ vars:
   CODE_DIRS: '{{"{{"}}.ROOT_DIR{{"}}"}}/cmd/... {{"{{"}}.ROOT_DIR{{"}}"}}/internal/... {{"{{"}}.ROOT_DIR{{"}}"}}/api/v1alpha1/... {{"{{"}}.ROOT_DIR{{"}}"}}/pkg/...'
   COMPONENTS: '{{.RepoName}}'
   REPO_URL: 'https://{{.Module}}'
+  COMMON_SCRIPT_DIR: '{{.ROOT_DIR}}/hack/common'
 
 includes:
   shared:
@@ -21,7 +22,7 @@ tasks:
       - docker tag ghcr.io/openmcp-project/images/{{"{{"}}.COMPONENTS{{"}}"}}:{{"{{"}}.VERSION{{"}}"}}-linux-{{"{{"}}ARCH{{"}}"}} ghcr.io/openmcp-project/images/{{"{{"}}.COMPONENTS{{"}}"}}:{{"{{"}}.VERSION{{"}}"}}
     vars:
       VERSION:
-        sh: cat VERSION
+        sh: $COMMON_SCRIPT_DIR/get-version.sh
       ARCH:
         sh: uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'
 

--- a/cmd/template/files/main_test.go.tmpl
+++ b/cmd/template/files/main_test.go.tmpl
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 		ServiceProviders: []providers.ServiceProviderSetup{
 			{
 				Name:               "{{.KindLower}}",
-				Image:              "ghcr.io/openmcp-project/images/{{.RepoName}}:v0.1.0",
+				Image:              fmt.Sprintf("ghcr/openmcp-project/images/{{.RepoName}}:%s", version),
 				LoadImageToCluster: true,
 			},
 		},

--- a/cmd/template/files/main_test.go.tmpl
+++ b/cmd/template/files/main_test.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"k8s.io/klog/v2"
@@ -18,6 +19,7 @@ var testenv env.Environment
 
 func TestMain(m *testing.M) {
 	initLogging()
+	version := mustVersion()
 	openmcp := setup.OpenMCPSetup{
 		Namespace: "openmcp-system",
 		Operator: setup.OpenMCPOperatorSetup{
@@ -43,6 +45,14 @@ func TestMain(m *testing.M) {
 	testenv = env.NewWithConfig(envconf.New().WithNamespace(openmcp.Namespace))
 	openmcp.Bootstrap(testenv)
 	os.Exit(testenv.Run(m))
+}
+
+func mustVersion() string {
+	version, err := os.ReadFile("../../VERSION")
+	if err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(string(version))
 }
 
 func initLogging() {

--- a/cmd/template/files/main_test.go.tmpl
+++ b/cmd/template/files/main_test.go.tmpl
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 		ServiceProviders: []providers.ServiceProviderSetup{
 			{
 				Name:               "{{.KindLower}}",
-				Image:              fmt.Sprintf("ghcr/openmcp-project/images/{{.RepoName}}:%s", version),
+				Image:              fmt.Sprintf("ghcr.io/openmcp-project/images/{{.RepoName}}:%s", version),
 				LoadImageToCluster: true,
 			},
 		},

--- a/cmd/template/files/main_test.go.tmpl
+++ b/cmd/template/files/main_test.go.tmpl
@@ -48,7 +48,8 @@ func TestMain(m *testing.M) {
 }
 
 func mustVersion() string {
-	version, err := os.ReadFile("../../VERSION")
+	cmd := exec.Command("../../hack/common/get-version.sh")
+	version, err := cmd.Output()
 	if err != nil {
 		panic(err)
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 		ServiceProviders: []providers.ServiceProviderSetup{
 			{
 				Name:               "foo",
-				Image:              fmt.Sprintf("ghcr/openmcp-project/images/service-provider-foo:%s", version),
+				Image:              fmt.Sprintf("ghcr.io/openmcp-project/images/service-provider-foo:%s", version),
 				LoadImageToCluster: true,
 			},
 		},

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -48,7 +49,8 @@ func TestMain(m *testing.M) {
 }
 
 func mustVersion() string {
-	version, err := os.ReadFile("../../VERSION")
+	cmd := exec.Command("../../hack/common/get-version.sh")
+	version, err := cmd.Output()
 	if err != nil {
 		panic(err)
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -2,7 +2,9 @@ package e2e
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"k8s.io/klog/v2"
@@ -17,6 +19,7 @@ var testenv env.Environment
 
 func TestMain(m *testing.M) {
 	initLogging()
+	version := mustVersion()
 	openmcp := setup.OpenMCPSetup{
 		Namespace: "openmcp-system",
 		Operator: setup.OpenMCPOperatorSetup{
@@ -34,7 +37,7 @@ func TestMain(m *testing.M) {
 		ServiceProviders: []providers.ServiceProviderSetup{
 			{
 				Name:               "foo",
-				Image:              "controller:latest",
+				Image:              fmt.Sprintf("ghcr/openmcp-project/images/service-provider-foo:%s", version),
 				LoadImageToCluster: true,
 			},
 		},
@@ -42,6 +45,14 @@ func TestMain(m *testing.M) {
 	testenv = env.NewWithConfig(envconf.New().WithNamespace(openmcp.Namespace))
 	openmcp.Bootstrap(testenv)
 	os.Exit(testenv.Run(m))
+}
+
+func mustVersion() string {
+	version, err := os.ReadFile("../../VERSION")
+	if err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(string(version))
 }
 
 func initLogging() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the static version usage from the e2e test and instead retrieves the latest image version from the VERSION file that is also used by the release job of the [build](https://github.com/openmcp-project/build?tab=readme-ov-file#github-actions-workflows) submodule. This prevents the e2e tests from failing when a new release automatically creates a new `-dev` version.

**Which issue(s) this PR fixes**:
Fixes #30 

**Special notes for your reviewer**:
Tested locally with dev and non-dev version. Created a [PR](https://github.com/openmcp-project/service-provider-velero/pull/19) for sp-velero to demonstrate the proposed solution with a real service provider.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
