### PR TITLE
chore: rename open control plane api group

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -3,7 +3,7 @@
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
 cliVersion: 4.8.0
-domain: openmcp.cloud
+domain: open-control-plane.io
 layout:
 - go.kubebuilder.io/v4
 projectName: sp-template
@@ -13,7 +13,7 @@ resources:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: openmcp.cloud
+  domain: open-control-plane.io
   group: foo.services
   kind: FooService
   path: github.com/openmcp-project/service-provider-template/api/v1alpha1
@@ -22,7 +22,7 @@ resources:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: openmcp.cloud
+  domain: open-control-plane.io
   group: foo.services
   kind: ProviderConfig
   path: github.com/openmcp-project/service-provider-template/api/v1alpha1

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The template generator (`cmd/template`) supports the following flags:
 
 - `-module`: Go module path (default: `github.com/openmcp-project/service-provider-template`)
 - `-kind`: GVK kind name (default: `FooService`)
-- `-group`: GVK group prefix, will be suffixed with `services.openmcp.cloud` (default: `foo`)
+- `-group`: GVK group prefix, will be suffixed with `services.open-control-plane.io` (default: `foo`)
 - `-v`: Generate with sample code (default: `false`)
 - `-w`: Generate a service provider that reconciles its `DomainServiceAPI` on the [WorkloadCluster](https://openmcp-project.github.io/docs/about/design/service-provider#deployment-model) (default: `false`)
 - `-s`: Generate secret watcher implementation (default: `false`)

--- a/api/crds/manifests/foo.services.open-control-plane.io_providerconfigs.yaml
+++ b/api/crds/manifests/foo.services.open-control-plane.io_providerconfigs.yaml
@@ -6,9 +6,9 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   labels:
     openmcp.cloud/cluster: platform
-  name: providerconfigs.foo.services.openmcp.cloud
+  name: providerconfigs.foo.services.open-control-plane.io
 spec:
-  group: foo.services.openmcp.cloud
+  group: foo.services.open-control-plane.io
   names:
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the services v1alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName=foo.services.openmcp.cloud
+// +groupName=foo.services.open-control-plane.io
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "foo.services.openmcp.cloud", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "foo.services.open-control-plane.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/cmd/template/files/api_crd_providerconfig.yaml.tmpl
+++ b/cmd/template/files/api_crd_providerconfig.yaml.tmpl
@@ -6,9 +6,9 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     openmcp.cloud/cluster: platform
-  name: providerconfigs.{{.Group}}.services.openmcp.cloud
+  name: providerconfigs.{{.Group}}.{{.GroupSuffix}}
 spec:
-  group: {{.Group}}.services.openmcp.cloud
+  group: {{.Group}}.{{.GroupSuffix}}
   names:
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/cmd/template/files/api_crd_serviceproviderapi.yaml.tmpl
+++ b/cmd/template/files/api_crd_serviceproviderapi.yaml.tmpl
@@ -6,9 +6,9 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   labels:
     openmcp.cloud/cluster: onboarding
-  name: {{.KindLower}}s.{{.Group}}.services.openmcp.cloud
+  name: {{.KindLower}}s.{{.Group}}.{{.GroupSuffix}}
 spec:
-  group: {{.Group}}.services.openmcp.cloud
+  group: {{.Group}}.{{.GroupSuffix}}
   names:
     kind: {{.Kind}}
     listKind: {{.Kind}}List

--- a/cmd/template/files/api_groupversion_info.go.tmpl
+++ b/cmd/template/files/api_groupversion_info.go.tmpl
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the services v1alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName={{.Group}}.services.openmcp.cloud
+// +groupName={{.Group}}.{{.GroupSuffix}}
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "{{.Group}}.services.openmcp.cloud", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "{{.Group}}.{{.GroupSuffix}}", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -243,7 +243,7 @@ func main() {
 		},
 	}
 	clusterAccessManager := clusteraccess.NewClusterAccessManager(platformCluster.Client(),
-		"{{.KindLower}}.{{.Group}}.services.openmcp.cloud", os.Getenv("POD_NAMESPACE"))
+		"{{.KindLower}}.{{.Group}}.{{.GroupSuffix}}", os.Getenv("POD_NAMESPACE"))
 	clusterAccessManager.WithLogger(&log).
 		WithInterval(10 * time.Second).
 		WithTimeout(30 * time.Minute)
@@ -292,7 +292,7 @@ func main() {
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "232f9e39.openmcp.cloud",
+		LeaderElectionID:       "{{.Module}}",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/cmd/template/files/testdata_providerconfig.yaml.tmpl
+++ b/cmd/template/files/testdata_providerconfig.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: {{.Group}}.services.openmcp.cloud/v1alpha1
+apiVersion: {{.Group}}.{{.GroupSuffix}}/v1alpha1
 kind: ProviderConfig
 metadata:
   name: {{.KindLower}}

--- a/cmd/template/files/testdata_service.yaml.tmpl
+++ b/cmd/template/files/testdata_service.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: {{.Group}}.services.openmcp.cloud/v1alpha1
+apiVersion: {{.Group}}.{{.GroupSuffix}}/v1alpha1
 kind: {{.Kind}}
 metadata:
   name: test-mcp

--- a/cmd/template/main.go
+++ b/cmd/template/main.go
@@ -27,6 +27,7 @@ type TemplateExecutionConfig struct {
 
 type TemplateData struct {
 	Group               string
+	GroupSuffix         string
 	Version             string
 	Kind                string
 	KindLower           string
@@ -37,9 +38,11 @@ type TemplateData struct {
 	WithSecretWatcher   bool
 }
 
+const groupSuffix = "services.open-control-plane.io"
+
 //nolint:gocyclo
 func main() {
-	group := flag.String("group", "foo", "GVK group prefix (will always be suffixed with services.openmcp.cloud)")
+	group := flag.String("group", "foo", fmt.Sprintf("GVK group prefix (will always be suffixed with %s", groupSuffix))
 	kind := flag.String("kind", "FooService", "GVK kind")
 	withExample := flag.Bool("v", false, "Generate with sample code")
 	withWorkloadCluster := flag.Bool("w", false, "Reconcile with workload cluster")
@@ -48,6 +51,7 @@ func main() {
 	flag.Parse()
 	data := TemplateData{
 		Group:               *group,
+		GroupSuffix:         groupSuffix,
 		Kind:                *kind,
 		KindLower:           strings.ToLower(*kind),
 		Module:              *module,
@@ -74,12 +78,12 @@ func main() {
 	templateConfigs := []TemplateExecutionConfig{
 		{
 			TemplateFile:    "api_crd_providerconfig.yaml.tmpl",
-			DestinationFile: filepath.Join(crdDir, fmt.Sprintf("%s.services.openmcp.cloud_providerconfigs.yaml", *group)),
+			DestinationFile: filepath.Join(crdDir, fmt.Sprintf("%s.%s_providerconfigs.yaml", *group, groupSuffix)),
 			Data:            data,
 		},
 		{
 			TemplateFile:    "api_crd_serviceproviderapi.yaml.tmpl",
-			DestinationFile: filepath.Join(crdDir, fmt.Sprintf("%s.services.openmcp.cloud_%ss.yaml", *group, data.KindLower)),
+			DestinationFile: filepath.Join(crdDir, fmt.Sprintf("%s.%s_%ss.yaml", *group, groupSuffix, data.KindLower)),
 			Data:            data,
 		},
 		{

--- a/test/e2e/platform/providerconfig.yaml
+++ b/test/e2e/platform/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: foo.services.openmcp.cloud/v1alpha1
+apiVersion: foo.{{.GroupSuffix}}/v1alpha1
 kind: ProviderConfig
 metadata:
   name: default


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

Context: https://github.com/openmcp-project/backlog/issues/567

**What this PR does / why we need it**:
This PR renames the API group name from `openmcp.cloud` to `open-control-plane.io`.

**Which issue(s) this PR fixes**:
Fixes #54 

**Special notes for your reviewer**:
I additionally replaced the static LeaderElectionID with the module name to prevent different service providers from using the same resource lock. I will also update existing service-providers to use the module name if they haven't updated the value of the old template version.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
