### PR TITLE
fix: enable `task generate` action

### DIFF
--- a/.github/workflows/renovate-generate.yaml
+++ b/.github/workflows/renovate-generate.yaml
@@ -1,0 +1,14 @@
+name: Renovate Generate
+
+on:
+  push:
+    branches:
+      - "renovate/**"
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    uses: openmcp-project/build/.github/workflows/renovate-generate.lib.yaml@b995e7b22d1fb90a7d9d477cad53fd825fc2bb82 # main
+    secrets: inherit

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "gitIgnoredAuthors": [
+    "github-actions[bot]@users.noreply.github.com"
+  ],
   "extends": [
     "config:recommended",
     "config:best-practices",


### PR DESCRIPTION
**What this PR does / why we need it**:

We have a [shared github action](https://github.com/openmcp-project/build/blob/main/.github/workflows/renovate-generate.lib.yaml) which is meant to run `task generate` on renovate PRs. This is useful, because there are sometimes renovate PRs which require this to be run, otherwise they cannot be merged. Without the action, a human user would need to manually checkout the branch, run `task generate` locally, commit the changes, and then find someone else to review the renovate PR since the user himself is not allowed to do that anymore. This is a very annoying workflow and the action was created to solve this problem. This PR adds the necessary configuration and enables the workflow for repositories created by this template.

**Which issue(s) this PR fixes**:
See explanation above.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The shared '[task generate](https://github.com/openmcp-project/build/blob/main/.github/workflows/renovate-generate.lib.yaml)' github action is now used by repositories created via this template.
```
