### PR TITLE
fix: gvk retrieval to trigger reconciliation on provider updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
+	github.com/go-logr/zapr v1.3.0
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/jsonreference v0.21.5 // indirect
 	github.com/go-openapi/swag v0.25.5 // indirect
@@ -72,7 +72,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.1 // indirect
+	go.uber.org/zap v1.27.1
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.35.0 // indirect

--- a/pkg/spruntime/pcreconciler.go
+++ b/pkg/spruntime/pcreconciler.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
@@ -61,6 +62,7 @@ func (r *PCReconciler[T]) WithUpdateChannel(c chan event.GenericEvent) *PCReconc
 
 // Reconcile acts as a sender to notify receivers about provider config changes .
 func (r *PCReconciler[T]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log.FromContext(ctx).Info("reconcile provider config")
 	obj := r.emptyObj()
 	notify := event.GenericEvent{}
 	if err := r.platformCluster.Client().Get(ctx, req.NamespacedName, obj); err != nil {

--- a/pkg/spruntime/spreconciler.go
+++ b/pkg/spruntime/spreconciler.go
@@ -440,6 +440,7 @@ func (r *SPReconciler[T, PC]) enqueueAllObjects(ctx context.Context) []reconcile
 	gvk, err := apiutil.GVKForObject(r.emptyObj(), r.onboardingCluster.Scheme())
 	if err != nil {
 		logf.FromContext(ctx).Error(err, "failed to retrieve gvk")
+		return nil
 	}
 	list.SetGroupVersionKind(gvk)
 	if err := r.onboardingCluster.Client().List(ctx, &list); err != nil {

--- a/pkg/spruntime/spreconciler.go
+++ b/pkg/spruntime/spreconciler.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -436,7 +437,10 @@ func (r *SPReconciler[T, PC]) mapSecretToRequests(sw SecretWatcher[PC]) func(ctx
 // enqueueAllObjects lists all ServiceProviderAPI objects and returns a reconcile request for each.
 func (r *SPReconciler[T, PC]) enqueueAllObjects(ctx context.Context) []reconcile.Request {
 	var list unstructured.UnstructuredList
-	gvk := r.emptyObj().GetObjectKind().GroupVersionKind()
+	gvk, err := apiutil.GVKForObject(r.emptyObj(), r.onboardingCluster.Scheme())
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "failed to retrieve gvk")
+	}
 	list.SetGroupVersionKind(gvk)
 	if err := r.onboardingCluster.Client().List(ctx, &list); err != nil {
 		logf.FromContext(ctx).Error(err, "failed to list objects")

--- a/pkg/spruntime/spreconciler_test.go
+++ b/pkg/spruntime/spreconciler_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -15,10 +19,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/go-logr/zapr"
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
 	"github.com/openmcp-project/openmcp-operator/api/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -436,7 +442,6 @@ func TestMapSecretToRequests(t *testing.T) {
 
 			r := NewSPReconciler[*fakeApiImpl, *fakeProviderConfigImpl](func() *fakeApiImpl {
 				obj := &fakeApiImpl{}
-				obj.SetGroupVersionKind(testGV.WithKind("fakeApiImpl"))
 				return obj
 			}).
 				WithOnboardingCluster(onboardingCluster).
@@ -459,6 +464,51 @@ func TestMapSecretToRequests(t *testing.T) {
 					assert.True(t, names[obj.GetName()], "expected request for object %s", obj.GetName())
 				}
 			}
+		})
+	}
+}
+
+func TestSPReconciler_enqueueAllObjects(t *testing.T) {
+	tests := []struct {
+		name              string // description of this test case
+		onboardingCluster *clusters.Cluster
+		wantErrorMessage  string
+		want              []reconcile.Request
+	}{
+		{
+			name: "expect reconcile requests",
+			onboardingCluster: createFakeClusterWithUnstructuredList(t, "onboarding", []client.Object{
+				&fakeApiImpl{ObjectMeta: metav1.ObjectMeta{Name: "obj-1", Namespace: testNamespaceName}},
+				&fakeApiImpl{ObjectMeta: metav1.ObjectMeta{Name: "obj-2", Namespace: testNamespaceName}},
+			}),
+			want: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: "obj-1", Namespace: testNamespaceName}},
+				{NamespacedName: types.NamespacedName{Name: "obj-2", Namespace: testNamespaceName}},
+			},
+		},
+		{
+			name:              "expect gvk error log without registering fake api scheme",
+			onboardingCluster: clusters.NewTestClusterFromClient("onboarding", fake.NewClientBuilder().Build()),
+			wantErrorMessage:  "failed to retrieve gvk",
+			want:              nil,
+		},
+	}
+	for _, tt := range tests {
+		core, observedLogs := observer.New(zap.ErrorLevel)
+		testContext := log.IntoContext(context.Background(), zapr.NewLogger(zap.New(core)))
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSPReconciler[*fakeApiImpl, *fakeProviderConfigImpl](func() *fakeApiImpl {
+				return &fakeApiImpl{}
+			})
+			r.onboardingCluster = tt.onboardingCluster
+			got := r.enqueueAllObjects(testContext)
+			if len(got) == 0 {
+				logs := observedLogs.All()
+				require.Len(t, logs, 1)
+				assert.Equal(t, zap.ErrorLevel, logs[0].Level)
+				assert.Equal(t, tt.wantErrorMessage, logs[0].Message)
+			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
This PR fixes the GVK retrieval to create reconcile requests on watched resources (provider configs and optional secret watches).

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
