### PR TITLE
feat: local cluster access

### DIFF
--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"os"
+	"strings"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -45,6 +46,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -53,6 +55,7 @@ import (
 
 	"github.com/openmcp-project/service-provider-template/pkg/spruntime"
 
+	localaccess "github.com/openmcp-project/service-provider-template/pkg/clusteraccess"
 	{{.KindLower}}sv1alpha1 "github.com/openmcp-project/service-provider-template/api/v1alpha1"
 	"github.com/openmcp-project/service-provider-template/internal/controller"
 	// +kubebuilder:scaffold:imports
@@ -103,6 +106,9 @@ func initWorkloadScheme() {
 }
 {{- end }}
 
+const ( 
+	debugEnvVar = "DEV_DEBUG"
+)
 // nolint:gocyclo
 func main() {
 	var command string
@@ -250,9 +256,7 @@ func main() {
 	ctx := context.Background()
 	// init (job that installs CRDs)
 	if command == "init" {
-		onboardingCluster, err := clusterAccessManager.CreateAndWaitForCluster(ctx, "onboarding-init",
-			clustersv1alpha1.PURPOSE_ONBOARDING, onboardingScheme, adminPermissions)
-
+		onboardingCluster, err := requestOnboardingClusterAccess(ctx, clusterAccessManager, platformCluster, adminPermissions, "init")
 		if err != nil {
 			setupLog.Error(err, "Failed to create and wait for onboarding cluster access")
 		}
@@ -279,8 +283,7 @@ func main() {
 		return
 	}
 	// run (sp controller deployment)
-	onboardingCluster, err := clusterAccessManager.CreateAndWaitForCluster(ctx, "onboarding-run",
-		clustersv1alpha1.PURPOSE_ONBOARDING, onboardingScheme, adminPermissions)
+	onboardingCluster, err := requestOnboardingClusterAccess(ctx, clusterAccessManager, platformCluster, adminPermissions, "run")
 	if err != nil {
 		setupLog.Error(err, "Failed to create and wait for onboarding cluster access")
 	}
@@ -313,7 +316,14 @@ func main() {
 		setupLog.Error(err, "unable to add platform cluster to manager")
 		os.Exit(1)
 	}
+	
 	providerConfigUpdates := make(chan event.GenericEvent)
+	
+	clusterAccessReconciler := clusteraccess.NewClusterAccessReconciler(platformCluster.Client(), "{{.Kind}}")
+	if debugEnabled() {
+		clusterAccessReconciler = localaccess.NewLocalAccessReconciler(clusterAccessReconciler)
+	}
+	
 	spr := spruntime.NewSPReconciler[*{{.KindLower}}sv1alpha1.{{.Kind}}, *{{.KindLower}}sv1alpha1.ProviderConfig](
 		func() *{{.KindLower}}sv1alpha1.{{.Kind}} { return &{{.KindLower}}sv1alpha1.{{.Kind}}{} },
 	).
@@ -327,7 +337,7 @@ func main() {
 			PlatformCluster:   platformCluster,
 			PodNamespace:      podNamespace,
 		}).
-		WithClusterAccessReconciler(clusteraccess.NewClusterAccessReconciler(platformCluster.Client(), "{{.Kind}}").
+		WithClusterAccessReconciler(clusterAccessReconciler.
 			WithMCPScheme(mcpScheme).
 			{{- if .WithWorkloadCluster }}
 			WithWorkloadScheme(workloadScheme).
@@ -391,4 +401,36 @@ func initializePlatformCluster() (*clusters.Cluster, error) {
 		return nil, err
 	}
 	return platformCluster, nil
+}
+
+func requestOnboardingClusterAccess(ctx context.Context, mgr clusteraccess.Manager, platformCluster *clusters.Cluster, permissions []clustersv1alpha1.PermissionsRequest, cmdSuffix string) (*clusters.Cluster, error) {
+	cluster, err := mgr.CreateAndWaitForCluster(ctx, "onboarding-"+cmdSuffix,
+		clustersv1alpha1.PURPOSE_ONBOARDING, onboardingScheme, permissions)
+	if err != nil {
+		return cluster, err
+	}
+	if debugEnabled() {
+		return patchOnboardingClient(ctx, platformCluster, cluster, "onboarding-"+cmdSuffix)
+	}
+	return cluster, nil
+}
+
+func patchOnboardingClient(ctx context.Context, platformCluster *clusters.Cluster, onboardingCluster *clusters.Cluster, cmdSuffix string) (*clusters.Cluster, error) {
+	onboardingAr := &clustersv1alpha1.AccessRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusteraccess.StableRequestNameFromLocalName("{{.KindLower}}.{{.Group}}.{{.GroupSuffix}}", cmdSuffix),
+			Namespace: os.Getenv("POD_NAMESPACE"),
+		},
+	}
+	if err := platformCluster.Client().Get(ctx, client.ObjectKeyFromObject(onboardingAr), onboardingAr); err != nil {
+		return onboardingCluster, err
+	}
+	return localaccess.MustPatchClusterClient(ctx, onboardingAr, onboardingCluster), nil
+}
+
+
+
+func debugEnabled() bool {
+	v := strings.ToLower(os.Getenv(debugEnvVar))
+	return v == "1" || v == "true"
 }

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/vladimirvivien/gexe v0.5.0 // indirect
+	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/streaming v0.36.1 // indirect
 	sigs.k8s.io/kind v0.31.0 // indirect
@@ -58,6 +59,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/openmcp-project/openmcp-operator/lib v0.19.1
 	github.com/openmcp-project/openmcp-testing v0.3.2
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/openmcp-project/controller-utils v0.27.1 h1:eMxmyS59+XQALX0uwg5t1Geas
 github.com/openmcp-project/controller-utils v0.27.1/go.mod h1:xK6o4ZYsGUTW7BI/iDFiaxbRQD5gp8vAtkO0X2VIG5s=
 github.com/openmcp-project/openmcp-operator/api v0.19.1 h1:QBOkyrWgXsK44wzecTuyo1HrFxEaaCSru5hIi49TuDk=
 github.com/openmcp-project/openmcp-operator/api v0.19.1/go.mod h1:I9Ro95BaGdpIfnJ6x1DeBWME1OfLSwpf0/BrlJoxWdQ=
+github.com/openmcp-project/openmcp-operator/lib v0.19.1 h1:lacyAhzu+4qDY223kdG9+L0ZOSwdKBXGGlHk1ArA0Z8=
+github.com/openmcp-project/openmcp-operator/lib v0.19.1/go.mod h1:uoZDOX8abQ3PYLtj1pNxBKmT1QP4tMTVULXU8hUELJU=
 github.com/openmcp-project/openmcp-testing v0.3.2 h1:nxtF+KXWjrwVNsWAVLP3/BmEMbv+JVOWudnWMzuXFls=
 github.com/openmcp-project/openmcp-testing v0.3.2/go.mod h1:imrQObuSwNkOFT7HPwPRmkYbmmlflweXf80kHxX0+Nc=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
@@ -163,6 +165,8 @@ go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
+golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=

--- a/pkg/clusteraccess/localaccess.go
+++ b/pkg/clusteraccess/localaccess.go
@@ -1,0 +1,136 @@
+package clusteraccess
+
+import (
+	"context"
+	"time"
+
+	"github.com/openmcp-project/controller-utils/pkg/clusters"
+	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
+	"github.com/openmcp-project/openmcp-operator/api/common"
+	"github.com/openmcp-project/openmcp-operator/lib/clusteraccess"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ clusteraccess.Reconciler = &localClusterAccessReconciler{}
+
+// localClusterAccessReconciler is used for local debugging to adjust cluster client configs.
+// Note that the builder methods have to be implemented to keep the pointer to the local impl
+// instead of the wrapped reconciler.
+type localClusterAccessReconciler struct {
+	clusteraccess.Reconciler
+}
+
+// NewLocalAccessReconciler returns a local cluster access reconciler that wraps the given cluster access reconciler
+func NewLocalAccessReconciler(car clusteraccess.Reconciler) clusteraccess.Reconciler {
+	return &localClusterAccessReconciler{
+		Reconciler: car,
+	}
+}
+
+// MCPCluster implements [ClusterAccessProvider].
+func (s *localClusterAccessReconciler) MCPCluster(ctx context.Context, request reconcile.Request) (*clusters.Cluster, error) {
+	cluster, err := s.Reconciler.MCPCluster(ctx, request)
+	if err != nil {
+		return cluster, err
+	}
+	ar, err := s.MCPAccessRequest(ctx, request)
+	if err != nil {
+		return cluster, err
+	}
+	// patch cluster client with annotation value
+	return MustPatchClusterClient(ctx, ar, cluster), err
+}
+
+// WorkloadCluster implements [ClusterAccessProvider].
+func (s *localClusterAccessReconciler) WorkloadCluster(ctx context.Context, request reconcile.Request) (*clusters.Cluster, error) {
+	cluster, err := s.Reconciler.WorkloadCluster(ctx, request)
+	if err != nil {
+		return cluster, err
+	}
+	ar, err := s.WorkloadAccessRequest(ctx, request)
+	if err != nil {
+		return cluster, err
+	}
+	// patch cluster client with annotation value
+	return MustPatchClusterClient(ctx, ar, cluster), err
+}
+
+// SkipWorkloadCluster implements [clusteraccess.Reconciler].
+func (s *localClusterAccessReconciler) SkipWorkloadCluster() clusteraccess.Reconciler {
+	s.Reconciler = s.Reconciler.SkipWorkloadCluster()
+	return s
+}
+
+// WithMCPPermissions implements [clusteraccess.Reconciler].
+func (s *localClusterAccessReconciler) WithMCPPermissions(permissions []clustersv1alpha1.PermissionsRequest) clusteraccess.Reconciler {
+	s.Reconciler = s.Reconciler.WithMCPPermissions(permissions)
+	return s
+}
+
+// WithMCPRoleRefs implements [clusteraccess.Reconciler].
+func (s *localClusterAccessReconciler) WithMCPRoleRefs(roleRefs []common.RoleRef) clusteraccess.Reconciler {
+	s.Reconciler = s.Reconciler.WithMCPRoleRefs(roleRefs)
+	return s
+}
+
+// WithMCPScheme implements [clusteraccess.Reconciler].
+func (s *localClusterAccessReconciler) WithMCPScheme(scheme *runtime.Scheme) clusteraccess.Reconciler {
+	s.Reconciler = s.Reconciler.WithMCPScheme(scheme)
+	return s
+}
+
+// WithRetryInterval implements [clusteraccess.Reconciler].
+func (s *localClusterAccessReconciler) WithRetryInterval(interval time.Duration) clusteraccess.Reconciler {
+	s.Reconciler = s.Reconciler.WithRetryInterval(interval)
+	return s
+}
+
+// WithWorkloadPermissions implements [clusteraccess.Reconciler].
+func (s *localClusterAccessReconciler) WithWorkloadPermissions(permissions []clustersv1alpha1.PermissionsRequest) clusteraccess.Reconciler {
+	s.Reconciler = s.Reconciler.WithWorkloadPermissions(permissions)
+	return s
+}
+
+// WithWorkloadRoleRefs implements [clusteraccess.Reconciler].
+func (s *localClusterAccessReconciler) WithWorkloadRoleRefs(roleRefs []common.RoleRef) clusteraccess.Reconciler {
+	s.Reconciler = s.Reconciler.WithWorkloadRoleRefs(roleRefs)
+	return s
+}
+
+// WithWorkloadScheme implements [clusteraccess.Reconciler].
+func (s *localClusterAccessReconciler) WithWorkloadScheme(scheme *runtime.Scheme) clusteraccess.Reconciler {
+	s.Reconciler = s.Reconciler.WithWorkloadScheme(scheme)
+	return s
+}
+
+// sample AR
+// apiVersion: clusters.openmcp.cloud/v1alpha1
+// kind: AccessRequest
+// metadata:
+//
+//	annotations:
+//	  kind.clusters.openmcp.cloud/localhost: https://127.0.0.1:42827
+const localAnnotationKey = "kind.clusters.openmcp.cloud/localhost"
+
+// MustPatchClusterClient replaces the cluster client with the host value of the local AR annotation
+// If no local annotation is present then the original cluster of the wrapped reconciler is returned.
+func MustPatchClusterClient(ctx context.Context, ar *clustersv1alpha1.AccessRequest, cluster *clusters.Cluster) *clusters.Cluster {
+	annotations := ar.GetAnnotations()
+	if annotations == nil {
+		logf.FromContext(ctx).Info("debug access provider used but no annotations set")
+		return cluster
+	}
+	if value, exists := annotations[localAnnotationKey]; exists {
+		restCfg := cluster.RESTConfig()
+		restCfg.Host = value
+		// re-init client
+		if err := cluster.InitializeClient(cluster.Client().Scheme()); err != nil {
+			panic(err)
+		}
+	} else {
+		logf.FromContext(ctx).Info("debug access provider used but no annotations set")
+	}
+	return cluster
+}

--- a/pkg/clusteraccess/localaccess.go
+++ b/pkg/clusteraccess/localaccess.go
@@ -40,7 +40,7 @@ func (s *localClusterAccessReconciler) MCPCluster(ctx context.Context, request r
 		return cluster, err
 	}
 	// patch cluster client with annotation value
-	return MustPatchClusterClient(ctx, ar, cluster), err
+	return MustPatchClusterClient(ctx, ar, cluster), nil
 }
 
 // WorkloadCluster implements [ClusterAccessProvider].
@@ -54,7 +54,7 @@ func (s *localClusterAccessReconciler) WorkloadCluster(ctx context.Context, requ
 		return cluster, err
 	}
 	// patch cluster client with annotation value
-	return MustPatchClusterClient(ctx, ar, cluster), err
+	return MustPatchClusterClient(ctx, ar, cluster), nil
 }
 
 // SkipWorkloadCluster implements [clusteraccess.Reconciler].
@@ -114,7 +114,7 @@ func (s *localClusterAccessReconciler) WithWorkloadScheme(scheme *runtime.Scheme
 //	  kind.clusters.openmcp.cloud/localhost: https://127.0.0.1:42827
 const localAnnotationKey = "kind.clusters.openmcp.cloud/localhost"
 
-// MustPatchClusterClient replaces the cluster client with the host value of the local AR annotation
+// MustPatchClusterClient replaces the cluster client with the host value of the local AR annotation.
 // If no local annotation is present then the original cluster of the wrapped reconciler is returned.
 func MustPatchClusterClient(ctx context.Context, ar *clustersv1alpha1.AccessRequest, cluster *clusters.Cluster) *clusters.Cluster {
 	annotations := ar.GetAnnotations()
@@ -122,15 +122,18 @@ func MustPatchClusterClient(ctx context.Context, ar *clustersv1alpha1.AccessRequ
 		logf.FromContext(ctx).Info("debug access provider used but no annotations set")
 		return cluster
 	}
-	if value, exists := annotations[localAnnotationKey]; exists {
-		restCfg := cluster.RESTConfig()
-		restCfg.Host = value
-		// re-init client
-		if err := cluster.InitializeClient(cluster.Client().Scheme()); err != nil {
-			panic(err)
-		}
-	} else {
-		logf.FromContext(ctx).Info("debug access provider used but no annotations set")
+
+	value, exists := annotations[localAnnotationKey]
+	if !exists {
+		logf.FromContext(ctx).Info("debug access provider used but local annotation key not found", "key", localAnnotationKey)
+		return cluster
+	}
+	restCfg := cluster.RESTConfig()
+	restCfg.Host = value
+
+	// re-init client
+	if err := cluster.InitializeClient(cluster.Client().Scheme()); err != nil {
+		panic(err)
 	}
 	return cluster
 }

--- a/pkg/clusteraccess/localaccess.go
+++ b/pkg/clusteraccess/localaccess.go
@@ -128,8 +128,13 @@ func MustPatchClusterClient(ctx context.Context, ar *clustersv1alpha1.AccessRequ
 		logf.FromContext(ctx).Info("debug access provider used but local annotation key not found", "key", localAnnotationKey)
 		return cluster
 	}
- 	cfg := *cluster.RESTConfig()                                                                                                                
-	cfg.Host = value                                                                                                                            
+
+	if value == "" {
+		logf.FromContext(ctx).Info("local annotation present but empty, skipping patch")
+		return cluster
+	}
+	cfg := *cluster.RESTConfig()
+	cfg.Host = value
 	cluster.WithRESTConfig(&cfg)
 
 	// re-init client

--- a/pkg/clusteraccess/localaccess.go
+++ b/pkg/clusteraccess/localaccess.go
@@ -128,8 +128,9 @@ func MustPatchClusterClient(ctx context.Context, ar *clustersv1alpha1.AccessRequ
 		logf.FromContext(ctx).Info("debug access provider used but local annotation key not found", "key", localAnnotationKey)
 		return cluster
 	}
-	restCfg := cluster.RESTConfig()
-	restCfg.Host = value
+ 	cfg := *cluster.RESTConfig()                                                                                                                
+	cfg.Host = value                                                                                                                            
+	cluster.WithRESTConfig(&cfg)
 
 	// re-init client
 	if err := cluster.InitializeClient(cluster.Client().Scheme()); err != nil {

--- a/pkg/clusteraccess/localaccess_test.go
+++ b/pkg/clusteraccess/localaccess_test.go
@@ -1,0 +1,224 @@
+package clusteraccess
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openmcp-project/controller-utils/pkg/clusters"
+	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
+	"github.com/openmcp-project/openmcp-operator/api/common"
+	"github.com/openmcp-project/openmcp-operator/lib/clusteraccess"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	inclusterAPIServer = "https://10.96.0.1:6443"
+	localAPIServer     = "https://127.0.0.1:12345"
+)
+
+func Test_localAccessProvider_MCPCluster(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		ar       *clustersv1alpha1.AccessRequest
+		cluster  *clusters.Cluster
+		wantHost string
+		wantErr  bool
+	}{
+		{
+			name: "local annotation results in local client config",
+			ar: &clustersv1alpha1.AccessRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mcp-access",
+					Namespace: metav1.NamespaceDefault,
+					Annotations: map[string]string{
+						localAnnotationKey: localAPIServer,
+					},
+				},
+			},
+			cluster:  createFakeCluster().WithRESTConfig(&rest.Config{Host: inclusterAPIServer}),
+			wantHost: localAPIServer,
+			wantErr:  false,
+		},
+		{
+			name: "no local annotation results in original cluster client config",
+			ar: &clustersv1alpha1.AccessRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mcp-access",
+					Namespace: metav1.NamespaceDefault,
+				},
+			},
+			cluster:  createFakeCluster().WithRESTConfig(&rest.Config{Host: inclusterAPIServer}),
+			wantHost: inclusterAPIServer,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeProvider := &fakeClusterAccessReconciler{
+				ManagedControlPlane:   tt.cluster,
+				ManagedControlPlaneAR: tt.ar,
+			}
+			localAccessProvider := NewLocalAccessReconciler(fakeProvider)
+			got, gotErr := localAccessProvider.MCPCluster(context.Background(), reconcile.Request{})
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("MCPCluster() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("MCPCluster() succeeded unexpectedly")
+			}
+			assert.Equal(t, tt.wantHost, got.RESTConfig().Host)
+		})
+	}
+}
+
+func Test_localAccessProvider_WorkloadCluster(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		ar       *clustersv1alpha1.AccessRequest
+		cluster  *clusters.Cluster
+		wantHost string
+		wantErr  bool
+	}{
+		{
+			name: "local annotation results in local client config",
+			ar: &clustersv1alpha1.AccessRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "workload-access",
+					Namespace: metav1.NamespaceDefault,
+					Annotations: map[string]string{
+						localAnnotationKey: localAPIServer,
+					},
+				},
+			},
+			cluster:  createFakeCluster().WithRESTConfig(&rest.Config{Host: inclusterAPIServer}),
+			wantHost: localAPIServer,
+			wantErr:  false,
+		},
+		{
+			name: "no local annotation results in original cluster client config",
+			ar: &clustersv1alpha1.AccessRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "workload-access",
+					Namespace: metav1.NamespaceDefault,
+				},
+			},
+			cluster:  createFakeCluster().WithRESTConfig(&rest.Config{Host: inclusterAPIServer}),
+			wantHost: inclusterAPIServer,
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeProvider := &fakeClusterAccessReconciler{
+				Workload:   tt.cluster,
+				WorkloadAR: tt.ar,
+			}
+			localAccessProvider := NewLocalAccessReconciler(fakeProvider)
+			got, gotErr := localAccessProvider.WorkloadCluster(context.Background(), reconcile.Request{})
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("WorkloadCluster() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("WorkloadCluster() succeeded unexpectedly")
+			}
+			assert.Equal(t, tt.wantHost, got.RESTConfig().Host)
+		})
+	}
+}
+
+var _ clusteraccess.Reconciler = &fakeClusterAccessReconciler{}
+
+type fakeClusterAccessReconciler struct {
+	ManagedControlPlane   *clusters.Cluster
+	ManagedControlPlaneAR *clustersv1alpha1.AccessRequest
+	Workload              *clusters.Cluster
+	WorkloadAR            *clustersv1alpha1.AccessRequest
+}
+
+// MCPAccessRequest implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) MCPAccessRequest(ctx context.Context, request reconcile.Request) (*clustersv1alpha1.AccessRequest, error) {
+	return f.ManagedControlPlaneAR, nil
+}
+
+// MCPCluster implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) MCPCluster(ctx context.Context, request reconcile.Request) (*clusters.Cluster, error) {
+	return f.ManagedControlPlane, nil
+}
+
+// Reconcile implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	panic("unimplemented")
+}
+
+// ReconcileDelete implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) ReconcileDelete(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	panic("unimplemented")
+}
+
+// SkipWorkloadCluster implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) SkipWorkloadCluster() clusteraccess.Reconciler {
+	panic("unimplemented")
+}
+
+// WithMCPPermissions implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) WithMCPPermissions(permissions []clustersv1alpha1.PermissionsRequest) clusteraccess.Reconciler {
+	panic("unimplemented")
+}
+
+// WithMCPRoleRefs implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) WithMCPRoleRefs(roleRefs []common.RoleRef) clusteraccess.Reconciler {
+	panic("unimplemented")
+}
+
+// WithMCPScheme implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) WithMCPScheme(scheme *runtime.Scheme) clusteraccess.Reconciler {
+	panic("unimplemented")
+}
+
+// WithRetryInterval implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) WithRetryInterval(interval time.Duration) clusteraccess.Reconciler {
+	panic("unimplemented")
+}
+
+// WithWorkloadPermissions implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) WithWorkloadPermissions(permissions []clustersv1alpha1.PermissionsRequest) clusteraccess.Reconciler {
+	panic("unimplemented")
+}
+
+// WithWorkloadRoleRefs implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) WithWorkloadRoleRefs(roleRefs []common.RoleRef) clusteraccess.Reconciler {
+	panic("unimplemented")
+}
+
+// WithWorkloadScheme implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) WithWorkloadScheme(scheme *runtime.Scheme) clusteraccess.Reconciler {
+	panic("unimplemented")
+}
+
+// WorkloadAccessRequest implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) WorkloadAccessRequest(ctx context.Context, request reconcile.Request) (*clustersv1alpha1.AccessRequest, error) {
+	return f.WorkloadAR, nil
+}
+
+// WorkloadCluster implements [clusteraccess.Reconciler].
+func (f *fakeClusterAccessReconciler) WorkloadCluster(ctx context.Context, request reconcile.Request) (*clusters.Cluster, error) {
+	return f.Workload, nil
+}
+
+func createFakeCluster() *clusters.Cluster {
+	return clusters.NewTestClusterFromClient("fakeCluster", fake.NewClientBuilder().Build())
+}


### PR DESCRIPTION


**What this PR does / why we need it**:
Adds a local cluster access provider for debugging service providers against local `cluster-provider-kind` platform cluster.. When the `DEV_DEBUG` environment variable is set, the service provider will use the  `kind.clusters.openmcp.cloud/localhost` annotation from `AccessRequest` objects and patches the cluster client's REST config host to point at the local cluster endpoint.

This enables developers to run and debug service providers out of the cluster without the need to rebuild and deploy the provider image on the cluster.

**Which issue(s) this PR fixes**:
Fixes #60 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added local cluster access provider for debugging service providers against `cluster-provider-kind` cluster using the `DEV_DEBUG` environment variable.
```
