### PR TITLE
feat: add annotation to skip reconciliation of ServiceProviderAPI

### DIFF
--- a/pkg/spruntime/spreconciler.go
+++ b/pkg/spruntime/spreconciler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
 	controllerutil2 "github.com/openmcp-project/controller-utils/pkg/controller"
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
+	apiconst "github.com/openmcp-project/openmcp-operator/api/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -199,6 +200,11 @@ func (r *SPReconciler[T, PC]) Reconcile(ctx context.Context, req ctrl.Request) (
 	obj := r.emptyObj()
 	if err := r.onboardingCluster.Client().Get(ctx, req.NamespacedName, obj); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	// Skip reconciliation if annotation is set
+	if obj.GetAnnotations()[apiconst.OperationAnnotation] == apiconst.OperationAnnotationValueIgnore {
+		l.Info("Skipping resource due to ignore operation annotation")
+		return ctrl.Result{}, nil
 	}
 	oldObj := obj.DeepCopyObject().(T)
 	providerConfig := r.providerConfig.Load()

--- a/pkg/spruntime/spreconciler_test.go
+++ b/pkg/spruntime/spreconciler_test.go
@@ -49,11 +49,12 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 	tests := []struct {
 		name string // description of this test case
 		// Named input parameters for target function.
-		apiObj         ServiceProviderAPI
-		providerConfig *fakeProviderConfigImpl
-		req            ctrl.Request
-		want           ctrl.Result
-		wantErr        bool
+		apiObj             ServiceProviderAPI
+		providerConfig     *fakeProviderConfigImpl
+		req                ctrl.Request
+		want               ctrl.Result
+		wantReconciliation bool
+		wantErr            bool
 	}{
 		{
 			name: "api obj createOrUpdate -> requeue with pc poll interval",
@@ -75,7 +76,8 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 			want: ctrl.Result{
 				RequeueAfter: time.Hour,
 			},
-			wantErr: false,
+			wantReconciliation: true,
+			wantErr:            false,
 		},
 		{
 			name: "api obj delete -> requeue with pc poll interval",
@@ -101,7 +103,8 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 			want: ctrl.Result{
 				RequeueAfter: time.Hour,
 			},
-			wantErr: false,
+			wantReconciliation: true,
+			wantErr:            false,
 		},
 		{
 			name: "api obj not found -> do not requeue",
@@ -124,8 +127,9 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 			providerConfig: &fakeProviderConfigImpl{
 				FakePollInterval: time.Hour,
 			},
-			want:    ctrl.Result{},
-			wantErr: false,
+			want:               ctrl.Result{},
+			wantReconciliation: false,
+			wantErr:            false,
 		},
 		{
 			name: "provider config not found -> error",
@@ -141,11 +145,12 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 					Namespace: testNamespaceName,
 				},
 			},
-			want:    ctrl.Result{},
-			wantErr: true,
+			want:               ctrl.Result{},
+			wantReconciliation: false,
+			wantErr:            true,
 		},
 		{
-			name: "Operation annotation -> ignore",
+			name: "Operation annotation ignore -> no reconciliation, no requeue",
 			apiObj: &fakeApiImpl{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testObjectName,
@@ -161,9 +166,10 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 					Namespace: testNamespaceName,
 				},
 			},
-			providerConfig: &fakeProviderConfigImpl{},
-			want:           ctrl.Result{},
-			wantErr:        false,
+			providerConfig:     &fakeProviderConfigImpl{},
+			want:               ctrl.Result{},
+			wantReconciliation: false,
+			wantErr:            false,
 		},
 	}
 	for _, tt := range tests {
@@ -218,26 +224,29 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 				t.Fatal("Reconcile() succeeded unexpectedly")
 			}
 			assert.Equal(t, tt.want, got)
-			if tt.apiObj.GetAnnotations()[apiconst.OperationAnnotation] == apiconst.OperationAnnotationValueIgnore {
+			assert.Equal(t, tt.wantReconciliation, mockSPR.createOrUpdateCalled || mockSPR.deleteCalled)
+
+			if !tt.wantReconciliation {
+				assert.False(t, mockSPR.createOrUpdateCalled)
+				assert.False(t, mockSPR.deleteCalled)
 				assert.Nil(t, mockSPR.apiObj)
 				assert.Nil(t, mockSPR.pcObj)
 				assert.Empty(t, mockSPR.contextObj.MCPAccessSecretKey)
 				assert.Empty(t, mockSPR.contextObj.WorkloadAccessSecretKey)
 				return
 			}
-			if tt.req.Name != testObjectNameNotFound {
-				// assert that the generic reconciler delegates objects to the target reconciler as expected
-				assert.Equal(t, client.ObjectKeyFromObject(tt.apiObj), client.ObjectKeyFromObject(mockSPR.apiObj))
-				assert.Equal(t, client.ObjectKeyFromObject(tt.providerConfig), client.ObjectKeyFromObject(mockSPR.pcObj))
-				assert.Equal(t, client.ObjectKey{
-					Namespace: tt.req.Namespace,
-					Name:      testMCPKubeconfig,
-				}, mockSPR.contextObj.MCPAccessSecretKey)
-				assert.Equal(t, client.ObjectKey{
-					Namespace: tt.req.Namespace,
-					Name:      testWorkloadKubeconfig,
-				}, mockSPR.contextObj.WorkloadAccessSecretKey)
-			}
+
+			// assert that the generic reconciler delegates objects to the target reconciler as expected
+			assert.Equal(t, client.ObjectKeyFromObject(tt.apiObj), client.ObjectKeyFromObject(mockSPR.apiObj))
+			assert.Equal(t, client.ObjectKeyFromObject(tt.providerConfig), client.ObjectKeyFromObject(mockSPR.pcObj))
+			assert.Equal(t, client.ObjectKey{
+				Namespace: tt.req.Namespace,
+				Name:      testMCPKubeconfig,
+			}, mockSPR.contextObj.MCPAccessSecretKey)
+			assert.Equal(t, client.ObjectKey{
+				Namespace: tt.req.Namespace,
+				Name:      testWorkloadKubeconfig,
+			}, mockSPR.contextObj.WorkloadAccessSecretKey)
 		})
 	}
 }
@@ -246,9 +255,11 @@ var _ ClusterAccessProvider = FakeClusterAccessProvider{}
 var _ ServiceProviderReconciler[*fakeApiImpl, *fakeProviderConfigImpl] = &MockServiceProviderReconciler{}
 
 type MockServiceProviderReconciler struct {
-	apiObj     ServiceProviderAPI
-	pcObj      ProviderConfig
-	contextObj ClusterContext
+	apiObj               ServiceProviderAPI
+	pcObj                ProviderConfig
+	contextObj           ClusterContext
+	createOrUpdateCalled bool
+	deleteCalled         bool
 }
 
 // CreateOrUpdate implements [runtime.ServiceProviderReconciler].
@@ -256,6 +267,7 @@ func (f *MockServiceProviderReconciler) CreateOrUpdate(_ context.Context, obj *f
 	f.apiObj = obj
 	f.pcObj = pc
 	f.contextObj = cc
+	f.createOrUpdateCalled = true
 	return reconcile.Result{}, nil
 }
 
@@ -264,6 +276,7 @@ func (f *MockServiceProviderReconciler) Delete(_ context.Context, obj *fakeApiIm
 	f.apiObj = obj
 	f.pcObj = pc
 	f.contextObj = cc
+	f.deleteCalled = true
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/spruntime/spreconciler_test.go
+++ b/pkg/spruntime/spreconciler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
 	"github.com/openmcp-project/openmcp-operator/api/common"
+	apiconst "github.com/openmcp-project/openmcp-operator/api/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -143,6 +144,27 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 			want:    ctrl.Result{},
 			wantErr: true,
 		},
+		{
+			name: "Operation annotation -> ignore",
+			apiObj: &fakeApiImpl{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testObjectName,
+					Namespace: testNamespaceName,
+					Annotations: map[string]string{
+						apiconst.OperationAnnotation: apiconst.OperationAnnotationValueIgnore,
+					},
+				},
+			},
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testObjectName,
+					Namespace: testNamespaceName,
+				},
+			},
+			providerConfig: &fakeProviderConfigImpl{},
+			want:           ctrl.Result{},
+			wantErr:        false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -196,6 +218,13 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 				t.Fatal("Reconcile() succeeded unexpectedly")
 			}
 			assert.Equal(t, tt.want, got)
+			if tt.apiObj.GetAnnotations()[apiconst.OperationAnnotation] == apiconst.OperationAnnotationValueIgnore {
+				assert.Nil(t, mockSPR.apiObj)
+				assert.Nil(t, mockSPR.pcObj)
+				assert.Empty(t, mockSPR.contextObj.MCPAccessSecretKey)
+				assert.Empty(t, mockSPR.contextObj.WorkloadAccessSecretKey)
+				return
+			}
 			if tt.req.Name != testObjectNameNotFound {
 				// assert that the generic reconciler delegates objects to the target reconciler as expected
 				assert.Equal(t, client.ObjectKeyFromObject(tt.apiObj), client.ObjectKeyFromObject(mockSPR.apiObj))


### PR DESCRIPTION
On-behalf-of: @SAP nico.andres@sap.com

**What this PR does / why we need it**:
Adds logic to process an annotation to skip reconciliation of ServiceProviderAPI

**Which issue(s) this PR fixes**:
Fixes #17

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add annotation to skip reconciliation of ServiceProviderAPI
```
