### PR TITLE
fix: update status on generic reconciler errros

### DIFF
--- a/pkg/spruntime/spreconciler.go
+++ b/pkg/spruntime/spreconciler.go
@@ -290,10 +290,8 @@ func (r *SPReconciler[T, PC]) delete(ctx context.Context, obj T, pc PC) (ctrl.Re
 		return res, nil
 	}
 	// remove finalizer
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.onboardingCluster.Client(), obj, func() error {
-		controllerutil.RemoveFinalizer(obj, obj.Finalizer())
-		return nil
-	}); err != nil {
+	controllerutil.RemoveFinalizer(obj, obj.Finalizer())
+	if err := r.onboardingCluster.Client().Update(ctx, obj); err != nil {
 		terminatingWithReason(obj, reasonReconcileError, "failed to remove finalizer")
 		return ctrl.Result{}, err
 	}

--- a/pkg/spruntime/spreconciler.go
+++ b/pkg/spruntime/spreconciler.go
@@ -194,7 +194,7 @@ func (r *SPReconciler[T, PC]) WithProviderConfig(config PC) *SPReconciler[T, PC]
 }
 
 // Reconcile orchestrates platform and DomainServiceReconciler logic to reconcile APIObjects
-func (r *SPReconciler[T, PC]) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *SPReconciler[T, PC]) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reconcileErr error) {
 	l := logf.FromContext(ctx)
 	// common reconciler logic including get obj, providerconfig, mcp/workload access
 	obj := r.emptyObj()
@@ -207,10 +207,16 @@ func (r *SPReconciler[T, PC]) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 	oldObj := obj.DeepCopyObject().(T)
+	// always try to update the obj status
+	defer func() {
+		if err := r.updateStatus(ctx, obj, oldObj); err != nil {
+			l.Error(err, "status update failed")
+			reconcileErr = errors.Join(reconcileErr, err)
+		}
+	}()
 	providerConfig := r.providerConfig.Load()
 	if providerConfig == nil {
-		StatusProgressing(obj, "ReconcileError", "No ProviderConfig found")
-		r.updateStatus(ctx, obj, oldObj)
+		StatusProgressing(obj, reasonReconcileError, "No ProviderConfig found")
 		return ctrl.Result{}, errors.New("provider config missing")
 	}
 	providerConfigCopy := (*providerConfig).DeepCopyObject().(PC)
@@ -222,7 +228,6 @@ func (r *SPReconciler[T, PC]) Reconcile(ctx context.Context, req ctrl.Request) (
 		res, err = r.delete(ctx, obj, providerConfigCopy)
 	} else {
 		res, err = r.createOrUpdate(ctx, obj, providerConfigCopy)
-		r.updateStatus(ctx, obj, oldObj)
 	}
 	// return based on result/err
 	if err != nil {
@@ -238,40 +243,35 @@ func (r *SPReconciler[T, PC]) Reconcile(ctx context.Context, req ctrl.Request) (
 	}, nil
 }
 
-func (r *SPReconciler[T, PC]) updateStatus(ctx context.Context, newObj T, oldObj T) {
+func (r *SPReconciler[T, PC]) updateStatus(ctx context.Context, newObj T, oldObj T) error {
 	if equality.Semantic.DeepEqual(oldObj.GetStatus(), newObj.GetStatus()) {
-		return
+		return nil
 	}
-	if err := r.onboardingCluster.Client().Status().Patch(ctx, newObj, client.MergeFrom(oldObj)); err != nil {
-		l := logf.FromContext(ctx)
-		l.Error(err, "Patch status failed")
-	}
+	err := r.onboardingCluster.Client().Status().Patch(ctx, newObj, client.MergeFrom(oldObj))
+	// can't update status if object doesn't exist
+	return client.IgnoreNotFound(err)
 }
 
 // delete eventually invokes the domain delete logic of a service provider and is the place to implement
 // common logic that should be abstracted away from a service provider developer like handling cluster access.
 func (r *SPReconciler[T, PC]) delete(ctx context.Context, obj T, pc PC) (ctrl.Result, error) {
-	l := logf.FromContext(ctx)
-	oldObj := obj.DeepCopyObject().(T)
-
 	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(obj)}
 	accessRequestsInDeletion, err := r.areAccessRequestsInDeletion(ctx, req)
 	if err != nil {
-		l.Error(err, "failed to check access requests in deletion")
+		StatusProgressing(obj, reasonReconcileError, "failed to check access requests in deletion")
 		return reconcile.Result{}, err
 	}
 	if !accessRequestsInDeletion {
 		clusters, res, err := r.clusters(ctx, req)
 		if err != nil {
-			StatusProgressing(obj, "ReconcileError", "cluster setup error")
+			terminatingWithReason(obj, reasonReconcileError, "cluster cleanup error")
 			return ctrl.Result{}, err
 		}
 		if res.RequeueAfter > 0 {
-			StatusProgressing(obj, "Reconciling", "clusters being setup")
+			terminatingWithReason(obj, "Reconciling", "cluster cleanup")
 			return res, nil
 		}
 		res, err = r.serviceProviderReconciler.Delete(ctx, obj, pc, clusters)
-		r.updateStatus(ctx, obj, oldObj)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -282,6 +282,7 @@ func (r *SPReconciler[T, PC]) delete(ctx context.Context, obj T, pc PC) (ctrl.Re
 	// remove cluster access
 	res, err := r.clusterAccessReconciler.ReconcileDelete(ctx, req)
 	if err != nil {
+		terminatingWithReason(obj, reasonReconcileError, "failed cluster access reconcile delete")
 		return ctrl.Result{}, err
 	}
 	// make sure to not drop the object before cleanup has been done
@@ -289,8 +290,11 @@ func (r *SPReconciler[T, PC]) delete(ctx context.Context, obj T, pc PC) (ctrl.Re
 		return res, nil
 	}
 	// remove finalizer
-	controllerutil.RemoveFinalizer(obj, obj.Finalizer())
-	if err := r.onboardingCluster.Client().Update(ctx, obj); err != nil {
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.onboardingCluster.Client(), obj, func() error {
+		controllerutil.RemoveFinalizer(obj, obj.Finalizer())
+		return nil
+	}); err != nil {
+		terminatingWithReason(obj, reasonReconcileError, "failed to remove finalizer")
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
@@ -303,11 +307,13 @@ func (r *SPReconciler[T, PC]) createOrUpdate(ctx context.Context, obj T, pc PC) 
 		controllerutil.AddFinalizer(obj, obj.Finalizer())
 		return nil
 	}); err != nil {
+		StatusProgressing(obj, reasonReconcileError, "failed to add finalizer")
 		return ctrl.Result{}, err
 	}
 	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(obj)}
 	clusters, res, err := r.clusters(ctx, req)
 	if err != nil {
+		StatusProgressing(obj, reasonReconcileError, "cluster setup error")
 		return ctrl.Result{}, err
 	}
 	if res.RequeueAfter > 0 {
@@ -342,7 +348,6 @@ func (r *SPReconciler[T, PC]) areAccessRequestsInDeletion(ctx context.Context, r
 // clusters returns any request scoped cluster that a servicer provider developer might want to access in order
 // to delivery its service.
 func (r *SPReconciler[T, PC]) clusters(ctx context.Context, req ctrl.Request) (ClusterContext, ctrl.Result, error) {
-	l := logf.FromContext(ctx)
 	clusters := ClusterContext{}
 	res, err := r.clusterAccessReconciler.Reconcile(ctx, req)
 	if err != nil {
@@ -367,7 +372,6 @@ func (r *SPReconciler[T, PC]) clusters(ctx context.Context, req ctrl.Request) (C
 	if r.withWorkloadCluster {
 		workloadCluster, err := r.clusterAccessReconciler.WorkloadCluster(ctx, req)
 		if err != nil {
-			l.Error(err, "workload cluster access error")
 			return clusters, ctrl.Result{}, err
 		}
 		if workloadCluster == nil {

--- a/pkg/spruntime/spreconciler_test.go
+++ b/pkg/spruntime/spreconciler_test.go
@@ -2,6 +2,8 @@ package spruntime
 
 import (
 	"context"
+	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -34,9 +36,10 @@ import (
 )
 
 const (
-	testNamespaceName      = "test-namespace"
-	testObjectName         = "test-name"
-	testObjectNameNotFound = "notfound"
+	testNamespaceName                = "test-namespace"
+	testObjectName                   = "test-name"
+	testObjectNameNotFound           = "notfound"
+	testObjectNameClusterAccessError = "clusteraccesserror"
 
 	testMCPName       = "mcp-name"
 	testMCPKubeconfig = "mcp-kubeconfig"
@@ -53,11 +56,12 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 		providerConfig     *fakeProviderConfigImpl
 		req                ctrl.Request
 		want               ctrl.Result
+		wantStatusPhase    string
 		wantReconciliation bool
 		wantErr            bool
 	}{
 		{
-			name: "api obj createOrUpdate -> requeue with pc poll interval",
+			name: "CreateOrUpdate ok -> requeue with pc poll interval",
 			apiObj: &fakeApiImpl{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testObjectName,
@@ -76,11 +80,34 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 			want: ctrl.Result{
 				RequeueAfter: time.Hour,
 			},
+			wantStatusPhase:    StatusPhaseReady,
 			wantReconciliation: true,
 			wantErr:            false,
 		},
 		{
-			name: "api obj delete -> requeue with pc poll interval",
+			name: "CreateOrUpdate error -> error and status update",
+			apiObj: &fakeApiImpl{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testObjectName,
+					Namespace: testNamespaceName,
+				},
+			},
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testObjectName,
+					Namespace: testNamespaceName,
+				},
+			},
+			providerConfig: &fakeProviderConfigImpl{
+				FakePollInterval: time.Hour,
+			},
+			want:               ctrl.Result{},
+			wantStatusPhase:    StatusPhaseProgressing,
+			wantReconciliation: true,
+			wantErr:            true,
+		},
+		{
+			name: "Delete ok -> requeue with pc poll interval",
 			apiObj: &fakeApiImpl{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testObjectName,
@@ -103,8 +130,35 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 			want: ctrl.Result{
 				RequeueAfter: time.Hour,
 			},
+			wantStatusPhase:    StatusPhaseTerminating,
 			wantReconciliation: true,
 			wantErr:            false,
+		},
+		{
+			name: "Delete error -> error and status update",
+			apiObj: &fakeApiImpl{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testObjectName,
+					Namespace: testNamespaceName,
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+					Finalizers: []string{"string"},
+				},
+			},
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testObjectName,
+					Namespace: testNamespaceName,
+				},
+			},
+			providerConfig: &fakeProviderConfigImpl{
+				FakePollInterval: time.Hour,
+			},
+			want:               ctrl.Result{},
+			wantStatusPhase:    StatusPhaseTerminating,
+			wantReconciliation: true,
+			wantErr:            true,
 		},
 		{
 			name: "api obj not found -> do not requeue",
@@ -128,6 +182,7 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 				FakePollInterval: time.Hour,
 			},
 			want:               ctrl.Result{},
+			wantStatusPhase:    "",
 			wantReconciliation: false,
 			wantErr:            false,
 		},
@@ -146,6 +201,7 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			want:               ctrl.Result{},
+			wantStatusPhase:    StatusPhaseProgressing,
 			wantReconciliation: false,
 			wantErr:            true,
 		},
@@ -171,12 +227,36 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 			wantReconciliation: false,
 			wantErr:            false,
 		},
+		{
+			name: "cluster access reconciler fails -> error and status update",
+			apiObj: &fakeApiImpl{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testObjectNameClusterAccessError,
+					Namespace: testNamespaceName,
+				},
+			},
+			providerConfig: &fakeProviderConfigImpl{
+				FakePollInterval: time.Hour,
+			},
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testObjectNameClusterAccessError,
+					Namespace: testNamespaceName,
+				},
+			},
+			want:               ctrl.Result{},
+			wantStatusPhase:    StatusPhaseProgressing,
+			wantReconciliation: true,
+			wantErr:            true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			onboardingCluster := createFakeCluster(t, "onboarding", tt.apiObj)
 			platformCluster := createFakeCluster(t, "platform")
-			mockSPR := &MockServiceProviderReconciler{}
+			mockSPR := &MockServiceProviderReconciler{
+				wantError: tt.wantErr,
+			}
 			r := NewSPReconciler[*fakeApiImpl, *fakeProviderConfigImpl](func() *fakeApiImpl {
 				return &fakeApiImpl{}
 			}).
@@ -218,6 +298,7 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 				if !tt.wantErr {
 					t.Errorf("Reconcile() failed: %v", gotErr)
 				}
+				assertStatusUpdate(t, onboardingCluster.Client(), tt.req, tt.wantStatusPhase)
 				return
 			}
 			if tt.wantErr {
@@ -247,8 +328,20 @@ func TestSPReconciler_Reconcile(t *testing.T) {
 				Namespace: tt.req.Namespace,
 				Name:      testWorkloadKubeconfig,
 			}, mockSPR.contextObj.WorkloadAccessSecretKey)
+			assertStatusUpdate(t, onboardingCluster.Client(), tt.req, tt.wantStatusPhase)
 		})
 	}
+}
+
+func assertStatusUpdate(t *testing.T, c client.Client, req ctrl.Request, wantStatusPhase string) {
+	t.Helper()
+	obj := &fakeApiImpl{}
+	obj.SetName(req.Name)
+	obj.SetNamespace(req.Namespace)
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(obj), obj))
+	status, ok := obj.GetStatus().(common.Status)
+	require.True(t, ok)
+	assert.Equal(t, wantStatusPhase, status.Phase)
 }
 
 var _ ClusterAccessProvider = FakeClusterAccessProvider{}
@@ -260,6 +353,7 @@ type MockServiceProviderReconciler struct {
 	contextObj           ClusterContext
 	createOrUpdateCalled bool
 	deleteCalled         bool
+	wantError            bool
 }
 
 // CreateOrUpdate implements [runtime.ServiceProviderReconciler].
@@ -268,6 +362,11 @@ func (f *MockServiceProviderReconciler) CreateOrUpdate(_ context.Context, obj *f
 	f.pcObj = pc
 	f.contextObj = cc
 	f.createOrUpdateCalled = true
+	if f.wantError {
+		StatusProgressing(obj, reasonReconcileError, "test error requested")
+		return reconcile.Result{}, errors.New("createOrUpdate failed")
+	}
+	StatusReady(obj)
 	return reconcile.Result{}, nil
 }
 
@@ -277,6 +376,10 @@ func (f *MockServiceProviderReconciler) Delete(_ context.Context, obj *fakeApiIm
 	f.pcObj = pc
 	f.contextObj = cc
 	f.deleteCalled = true
+	StatusTerminating(obj)
+	if f.wantError {
+		return reconcile.Result{}, errors.New("delete failed")
+	}
 	return reconcile.Result{}, nil
 }
 
@@ -299,12 +402,19 @@ func (f FakeClusterAccessProvider) MCPCluster(ctx context.Context, request recon
 
 // Reconcile implements [ClusterAccessProvider].
 func (f FakeClusterAccessProvider) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	if request.Name == testObjectNameClusterAccessError {
+		return reconcile.Result{}, errors.New("cluster access reconcile failed")
+	}
 	return reconcile.Result{}, nil
 }
 
 // ReconcileDelete implements [ClusterAccessProvider].
 func (f FakeClusterAccessProvider) ReconcileDelete(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	return reconcile.Result{}, nil
+	// Fake waiting for cluster acccess deletion.
+	// This prevents finalizer removal in the delete case and the fake client from losing the not yet persisted terminating state.
+	return reconcile.Result{
+		RequeueAfter: time.Hour,
+	}, nil
 }
 
 // WorkloadAccessRequest implements [ClusterAccessProvider].
@@ -328,20 +438,31 @@ func createFakeCluster(t *testing.T, id string, clusterObjects ...client.Object)
 	scheme.AddKnownTypes(testGV, &fakeApiImpl{}, &fakeProviderConfigImpl{})
 
 	// init cluster with objects
-	fakeClient := fake.NewClientBuilder().WithObjects(clusterObjects...).WithScheme(scheme).Build()
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(clusterObjects...).
+		WithScheme(scheme).
+		WithStatusSubresource(&fakeApiImpl{}).
+		Build()
 	return clusters.NewTestClusterFromClient(id, fakeClient)
 }
 
 var _ ServiceProviderAPI = &fakeApiImpl{}
 
 type fakeApiImpl struct {
-	metav1.TypeMeta
-	metav1.ObjectMeta
-	common.Status
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	common.Status     `json:"status,omitempty"`
 }
 
 func (f *fakeApiImpl) DeepCopyObject() runtime.Object {
-	return f
+	return &fakeApiImpl{
+		ObjectMeta: *f.ObjectMeta.DeepCopy(),
+		Status: common.Status{
+			ObservedGeneration: f.ObservedGeneration,
+			Phase:              f.Phase,
+			Conditions:         slices.Clone(f.Conditions),
+		},
+	}
 }
 
 func (f *fakeApiImpl) Finalizer() string {
@@ -349,7 +470,7 @@ func (f *fakeApiImpl) Finalizer() string {
 }
 
 func (f *fakeApiImpl) GetConditions() *[]metav1.Condition {
-	return nil
+	return &f.Conditions
 }
 
 func (f *fakeApiImpl) GetStatus() any {
@@ -357,8 +478,10 @@ func (f *fakeApiImpl) GetStatus() any {
 }
 
 func (f *fakeApiImpl) SetPhase(phase string) {
+	f.Phase = phase
 }
 func (f *fakeApiImpl) SetObservedGeneration(g int64) {
+	f.ObservedGeneration = g
 }
 
 var _ ProviderConfig = &fakeProviderConfigImpl{}

--- a/pkg/spruntime/status.go
+++ b/pkg/spruntime/status.go
@@ -15,6 +15,8 @@ const (
 	StatusPhaseProgressing = "Progressing"
 	// StatusPhaseTerminating indicates that the resource is not ready and in deletion.
 	StatusPhaseTerminating = "Terminating"
+
+	reasonReconcileError = "ReconcileError"
 )
 
 // StatusProgressing indicates progressing with synced false
@@ -51,6 +53,18 @@ func StatusTerminating(obj ServiceProviderAPI) {
 		ObservedGeneration: obj.GetGeneration(),
 		Reason:             "Terminating",
 		Message:            "Cleanup in progress",
+	})
+	obj.SetObservedGeneration(obj.GetGeneration())
+	obj.SetPhase(StatusPhaseTerminating)
+}
+
+func terminatingWithReason(obj ServiceProviderAPI, reason, message string) {
+	meta.SetStatusCondition(obj.GetConditions(), metav1.Condition{
+		Type:               ServiceProviderConditionReady,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: obj.GetGeneration(),
+		Reason:             reason,
+		Message:            message,
 	})
 	obj.SetObservedGeneration(obj.GetGeneration())
 	obj.SetPhase(StatusPhaseTerminating)


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
This PR fixes missing status updates on errors inside the generic reconciler logic, e.g. errors of the cluster access reconciler.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Additionally contains some minor changes like implementing the remove finalizer logic the same way as the add finalizer.

I also tested this with service-provider-flux by completely replacing the spruntime package with the version of this PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
