### PR TITLE
fix: use group domain for ClusterRequests and AccessRequests

### DIFF
--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -105,7 +105,7 @@ func initWorkloadScheme() {
 }
 {{- end }}
 
-const ( 
+const (
 	debugEnvVar = "DEV_DEBUG"
 )
 // nolint:gocyclo
@@ -248,7 +248,7 @@ func main() {
 		},
 	}
 	clusterAccessManager := clusteraccess.NewClusterAccessManager(platformCluster.Client(),
-		"{{.KindLower}}.{{.Group}}.{{.GroupSuffix}}", os.Getenv("POD_NAMESPACE"))
+		{{.KindLower}}sv1alpha1.GroupVersion.Group, os.Getenv("POD_NAMESPACE"))
 	clusterAccessManager.WithLogger(&log).
 		WithInterval(10 * time.Second).
 		WithTimeout(30 * time.Minute)
@@ -315,14 +315,14 @@ func main() {
 		setupLog.Error(err, "unable to add platform cluster to manager")
 		os.Exit(1)
 	}
-	
+
 	providerConfigUpdates := make(chan event.GenericEvent)
-	
+
 	clusterAccessReconciler := clusteraccess.NewClusterAccessReconciler(platformCluster.Client(), "{{.Kind}}")
 	if debugEnabled() {
 		clusterAccessReconciler = localaccess.NewLocalAccessReconciler(clusterAccessReconciler)
 	}
-	
+
 	spr := serviceprovider.NewAPIReconcilerBuilder[*{{.KindLower}}sv1alpha1.{{.Kind}}, *{{.KindLower}}sv1alpha1.ProviderConfig]().
 		EmptyObjectProvider(func() *{{.KindLower}}sv1alpha1.{{.Kind}} { return &{{.KindLower}}sv1alpha1.{{.Kind}}{} }).
 		PlatformCluster(platformCluster).
@@ -418,7 +418,7 @@ func requestOnboardingClusterAccess(ctx context.Context, mgr clusteraccess.Manag
 func patchOnboardingClient(ctx context.Context, platformCluster *clusters.Cluster, onboardingCluster *clusters.Cluster, cmdSuffix string) (*clusters.Cluster, error) {
 	onboardingAr := &clustersv1alpha1.AccessRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusteraccess.StableRequestNameFromLocalName("{{.KindLower}}.{{.Group}}.{{.GroupSuffix}}", cmdSuffix),
+			Name:      clusteraccess.StableRequestNameFromLocalName({{.KindLower}}sv1alpha1.GroupVersion.Group, cmdSuffix),
 			Namespace: os.Getenv("POD_NAMESPACE"),
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug that occurred already in https://github.com/openmcp-project/service-provider-flux/pull/58. It uses the API `GroupVersion.Group` value for all `ClusterRequests` and `AccessRequests`

The new `ClusteRequests` and `AccessRequests` will have the structure `foo.services.open-control-plane.io`.

**Which issue(s) this PR fixes**:
Related https://github.com/openmcp-project/service-provider-flux/pull/58

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Using API GroupVersion.Group name consistently for creating `ClsuterRequests` and `AccessRequests
```
