### PR TITLE
docs: add Quality Criteria self-assessment scaffold to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- Update the tier badge and tick each criterion as you implement it. See https://open-control-plane.io/developers/serviceprovider/quality-criteria for definitions. -->
 
-[![Quality: Incubating](https://img.shields.io/badge/Quality-Incubating-3d9970?style=flat-square&labelColor=555)](https://open-control-plane.io/developers/serviceprovider/quality-criteria)
+[![Quality: Experimental](https://img.shields.io/badge/Quality-Experimental-e69138?style=flat-square&labelColor=555)](https://open-control-plane.io/developers/serviceprovider/quality-criteria)
 
 | Criterion                         | Status  | Notes |
 | --------------------------------- | :----:  | ----- |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 # service-provider-template
 
+## Quality Criteria
+
+<!-- Update the tier badge and tick each criterion as you implement it. See https://open-control-plane.io/developers/serviceprovider/quality-criteria for definitions. -->
+
+[![Quality: Incubating](https://img.shields.io/badge/Quality-Incubating-3d9970?style=flat-square&labelColor=555)](https://open-control-plane.io/developers/serviceprovider/quality-criteria)
+
+| Criterion                         | Status  | Notes |
+| --------------------------------- | :----:  | ----- |
+| Deletion behaviour                |   ❌    |       |
+| Status reporting & error messages |   ❌    |       |
+| Operation annotations             |   ❌    |       |
+| API stability policy              |   ❌    |       |
+| Custom CA support                 |   ❌    |       |
+| Release artifacts (image + OCM)   |   ❌    |       |
+| Testing                           |   ❌    |       |
+| Ownership and maintenance docs    |   ❌    |       |
+
+See the [OpenControlPlane Quality Criteria](https://open-control-plane.io/developers/serviceprovider/quality-criteria) for definitions.
+
 ## About this project
 
 A template for building @openmcp-project Service Providers.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a Quality Criteria scaffold to the README so providers created from this template start with the table in place. Implementers tick each row as they meet the criterion.

**Which issue(s) this PR fixes**:
Refs openmcp-project/docs#49

**Special notes for your reviewer**:
All 8 rows ship as ❌. They are placeholders for the downstream maintainer to update. The Notes column is empty for the same reason.

**Release note**:
```doc developer
Add Quality Criteria self-assessment scaffold to the README.
```