### PR TITLE
feat: replace simple cluster access reconciler with advanced cluster access reconciler

### DIFF
--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -329,6 +329,7 @@ func main() {
 
 	providerConfigUpdates := make(chan event.GenericEvent)
 
+	// TODO: define minimum set of permission the service provider requires on the mcp cluster
 	mcpTokenAccessConfig := &clustersv1alpha1.TokenConfig{
 		Permissions: []clustersv1alpha1.PermissionsRequest{
 			{
@@ -364,6 +365,7 @@ func main() {
 		Build()
 	{{- if .WithWorkloadCluster }}
 
+	// TODO: define minimum set of permission the service provider requires on the workload cluster
 	workloadTokenAccessConfig := &clustersv1alpha1.TokenConfig{
 		Permissions: []clustersv1alpha1.PermissionsRequest{
 			{

--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -348,7 +348,6 @@ func main() {
 			},
 		},
 	}
-
 	mcpClusterRequest := advanced.ExistingClusterRequest("mcp", "mcp", func(req reconcile.Request, _ ...any) (*common.ObjectReference, error) {
 		namespace, err := utils.StableMCPNamespace(req.Name, req.Namespace)
 		if err != nil {
@@ -384,7 +383,6 @@ func main() {
 			},
 		},
 	}
-
 	workloadClusterRequest := advanced.NewClusterRequest("workload", "wl", advanced.StaticClusterRequestSpecGenerator(&clustersv1alpha1.ClusterRequestSpec{
 			Purpose: clustersv1alpha1.PURPOSE_WORKLOAD,
 		})).

--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -235,18 +235,6 @@ func main() {
 		setupLog.Error(fmt.Errorf("environment variable %s not set - cannot determine source namespace for secrets", openmcpconst.EnvVariablePodNamespace), "pod namespace missing")
 		os.Exit(1)
 	}
-	initPermissions := []clustersv1alpha1.PermissionsRequest{
-		{
-
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{"apiextensions.k8s.io"},
-					Resources: []string{"customresourcedefinitions"},
-					Verbs:     []string{"*"},
-				},
-			},
-		},
-	}
 	clusterAccessManager := clusteraccess.NewClusterAccessManager(platformCluster.Client(),
 		{{.KindLower}}sv1alpha1.GroupVersion.Group, os.Getenv("POD_NAMESPACE"))
 	clusterAccessManager.WithLogger(&log).
@@ -255,6 +243,18 @@ func main() {
 	ctx := context.Background()
 	// init (job that installs CRDs)
 	if command == "init" {
+		initPermissions := []clustersv1alpha1.PermissionsRequest{
+			{
+
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"apiextensions.k8s.io"},
+						Resources: []string{"customresourcedefinitions"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+		}
 		onboardingCluster, err := requestOnboardingClusterAccess(ctx, clusterAccessManager, platformCluster, initPermissions, "init")
 		if err != nil {
 			setupLog.Error(err, "Failed to create and wait for onboarding cluster access")

--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -35,6 +35,7 @@ import (
 	openmcpconst "github.com/openmcp-project/openmcp-operator/api/constants"
 	providerv1alpha1 "github.com/openmcp-project/openmcp-operator/api/provider/v1alpha1"
 	"github.com/openmcp-project/openmcp-operator/lib/clusteraccess"
+	"github.com/openmcp-project/openmcp-operator/lib/clusteraccess/advanced"
 	"github.com/openmcp-project/openmcp-operator/lib/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -234,14 +235,13 @@ func main() {
 		setupLog.Error(fmt.Errorf("environment variable %s not set - cannot determine source namespace for secrets", openmcpconst.EnvVariablePodNamespace), "pod namespace missing")
 		os.Exit(1)
 	}
-	// TODO: define minimum set of permission required to run the init and run part of your service provider
-	adminPermissions := []clustersv1alpha1.PermissionsRequest{
+	initPermissions := []clustersv1alpha1.PermissionsRequest{
 		{
 
 			Rules: []rbacv1.PolicyRule{
 				{
-					APIGroups: []string{"*"},
-					Resources: []string{"*"},
+					APIGroups: []string{"apiextensions.k8s.io"},
+					Resources: []string{"customresourcedefinitions"},
 					Verbs:     []string{"*"},
 				},
 			},
@@ -255,7 +255,7 @@ func main() {
 	ctx := context.Background()
 	// init (job that installs CRDs)
 	if command == "init" {
-		onboardingCluster, err := requestOnboardingClusterAccess(ctx, clusterAccessManager, platformCluster, adminPermissions, "init")
+		onboardingCluster, err := requestOnboardingClusterAccess(ctx, clusterAccessManager, platformCluster, initPermissions, "init")
 		if err != nil {
 			setupLog.Error(err, "Failed to create and wait for onboarding cluster access")
 		}
@@ -282,7 +282,18 @@ func main() {
 		return
 	}
 	// run (sp controller deployment)
-	onboardingCluster, err := requestOnboardingClusterAccess(ctx, clusterAccessManager, platformCluster, adminPermissions, "run")
+	runPermissions := []clustersv1alpha1.PermissionsRequest{
+		{
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{ {{- .KindLower}}sv1alpha1.GroupVersion.Group},
+					Resources: []string{"*"},
+					Verbs:     []string{"*"},
+				},
+			},
+		},
+	}
+	onboardingCluster, err := requestOnboardingClusterAccess(ctx, clusterAccessManager, platformCluster, runPermissions, "run")
 	if err != nil {
 		setupLog.Error(err, "Failed to create and wait for onboarding cluster access")
 	}
@@ -318,10 +329,89 @@ func main() {
 
 	providerConfigUpdates := make(chan event.GenericEvent)
 
-	clusterAccessReconciler := clusteraccess.NewClusterAccessReconciler(platformCluster.Client(), "{{.Kind}}")
-	if debugEnabled() {
-		clusterAccessReconciler = localaccess.NewLocalAccessReconciler(clusterAccessReconciler)
+	mcpTokenAccessConfig := &clustersv1alpha1.TokenConfig{
+		Permissions: []clustersv1alpha1.PermissionsRequest{
+			{
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"*"},
+						Resources: []string{"*"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+		},
+		RoleRefs: []common.RoleRef{
+			{
+				Name: "cluster-admin",
+				Kind: "ClusterRole",
+			},
+		},
 	}
+
+	mcpClusterRequest := advanced.ExistingClusterRequest("mcp", "mcp", func(req reconcile.Request, _ ...any) (*common.ObjectReference, error) {
+		namespace, err := utils.StableMCPNamespace(req.Name, req.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		return &common.ObjectReference{
+			Name:      req.Name,
+			Namespace: namespace,
+		}, nil
+	}).
+		WithNamespaceGenerator(advanced.DefaultNamespaceGeneratorForMCP).
+		WithTokenAccess(mcpTokenAccessConfig).
+		WithScheme(mcpScheme).
+		Build()
+	{{- if .WithWorkloadCluster }}
+
+	workloadTokenAccessConfig := &clustersv1alpha1.TokenConfig{
+		Permissions: []clustersv1alpha1.PermissionsRequest{
+			{
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"*"},
+						Resources: []string{"*"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+		},
+		RoleRefs: []common.RoleRef{
+			{
+				Name: "cluster-admin",
+				Kind: "ClusterRole",
+			},
+		},
+	}
+
+	workloadClusterRequest := advanced.NewClusterRequest("workload", "wl", advanced.StaticClusterRequestSpecGenerator(&clustersv1alpha1.ClusterRequestSpec{
+			Purpose: clustersv1alpha1.PURPOSE_WORKLOAD,
+		})).
+		WithNamespaceGenerator(advanced.DefaultNamespaceGeneratorForMCP).
+		WithTokenAccess(workloadTokenAccessConfig).
+		WithScheme(workloadScheme).
+		Build()
+	{{- end }}
+
+	clusterAccessReconciler := advanced.NewClusterAccessReconciler(platformCluster.Client(), "{{.Kind}}")
+	if debugEnabled() {
+		clusterAccessReconciler = localaccess.NewLocalAdvancedClusterAccessReconciler(clusterAccessReconciler)
+	}
+
+	clusterAccessReconciler.
+		WithManagedLabels(func(controllerName string, req reconcile.Request, reg advanced.ClusterRegistration) (string, string, map[string]string) {
+			_, managedPurpose, _ := advanced.DefaultManagedLabelGenerator(controllerName, req, reg)
+			return controllerName, managedPurpose, map[string]string{
+				openmcpconst.OnboardingNameLabel:      req.Name,
+				openmcpconst.OnboardingNamespaceLabel: req.Namespace,
+			}
+		}).
+		Register(mcpClusterRequest).
+		{{- if .WithWorkloadCluster }}
+		Register(workloadClusterRequest).
+		{{- end }}
+		WithRetryInterval(10 * time.Second)
 
 	spr := serviceprovider.NewAPIReconcilerBuilder[*{{.KindLower}}sv1alpha1.{{.Kind}}, *{{.KindLower}}sv1alpha1.ProviderConfig]().
 		EmptyObjectProvider(func() *{{.KindLower}}sv1alpha1.{{.Kind}} { return &{{.KindLower}}sv1alpha1.{{.Kind}}{} }).
@@ -335,28 +425,7 @@ func main() {
 			PlatformCluster:   platformCluster,
 			PodNamespace:      podNamespace,
 		}).
-		ClusterAccessReconciler(clusterAccessReconciler.
-			WithMCPScheme(mcpScheme).
-			{{- if .WithWorkloadCluster }}
-			WithWorkloadScheme(workloadScheme).
-			{{- end }}
-			WithRetryInterval(10 * time.Second).
-			WithMCPPermissions(adminPermissions).WithMCPRoleRefs([]common.RoleRef{
-			{
-				Name: "cluster-admin",
-				Kind: "ClusterRole",
-			}}).
-			{{- if .WithWorkloadCluster }}
-			WithWorkloadPermissions(adminPermissions).WithWorkloadRoleRefs([]common.RoleRef{
-			{
-				Name: "cluster-admin",
-				Kind: "ClusterRole",
-			},
-		})).
-			{{- else }}
-			SkipWorkloadCluster(),
-		).
-			{{- end }}
+		AdvancedClusterAccessReconciler(clusterAccessReconciler).
 		MustBuild()
 	if err := spr.SetupWithManager(mgr, "{{.KindLower}}", providerConfigUpdates); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "{{.Kind}}")

--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -394,7 +394,7 @@ func main() {
 		Build()
 	{{- end }}
 
-	clusterAccessReconciler := advanced.NewClusterAccessReconciler(platformCluster.Client(), "{{.Kind}}")
+	clusterAccessReconciler := advanced.NewClusterAccessReconciler(platformCluster.Client(), providerName)
 	if debugEnabled() {
 		clusterAccessReconciler = localaccess.NewLocalAdvancedClusterAccessReconciler(clusterAccessReconciler)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace simple cluster access reconciler with the advanced cluster access reconciler
Implementation is 1to1 mapping of what the simple reconciler [called](https://github.com/openmcp-project/openmcp-operator/blob/045b213389c43c37bf82bf5dda37292b04b7f48d/lib/clusteraccess/clusteraccess.go) 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Replace simple cluster access reconciler with the advanced cluster access reconciler
```
