### PR TITLE
feat: use opencontrolplane-runtime v1

### DIFF
--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -327,8 +327,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	providerConfigUpdates := make(chan event.GenericEvent)
-
 	// TODO: define minimum set of permission the service provider requires on the mcp cluster
 	mcpTokenAccessConfig := &clustersv1alpha1.TokenConfig{
 		Permissions: []clustersv1alpha1.PermissionsRequest{
@@ -415,6 +413,7 @@ func main() {
 
 	spr := serviceprovider.NewAPIReconcilerBuilder[*{{.KindLower}}sv1alpha1.{{.Kind}}, *{{.KindLower}}sv1alpha1.ProviderConfig]().
 		EmptyObjectProvider(func() *{{.KindLower}}sv1alpha1.{{.Kind}} { return &{{.KindLower}}sv1alpha1.{{.Kind}}{} }).
+		EmptyConfigProvider(func() *{{.KindLower}}sv1alpha1.ProviderConfig { return &{{.KindLower}}sv1alpha1.ProviderConfig{} }).
 		PlatformCluster(platformCluster).
 		OnboardingCluster(onboardingCluster).
 		{{- if .WithSecretWatcher }}
@@ -427,18 +426,8 @@ func main() {
 		}).
 		AdvancedClusterAccessReconciler(clusterAccessReconciler).
 		MustBuild()
-	if err := spr.SetupWithManager(mgr, "{{.KindLower}}", providerConfigUpdates); err != nil {
+	if err := spr.SetupWithManager(mgr, "{{.KindLower}}"); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "{{.Kind}}")
-		os.Exit(1)
-	}
-	pcr := serviceprovider.NewConfigReconcilerBuilder[*{{.KindLower}}sv1alpha1.ProviderConfig]().
-		EmptyObjectProvider(func() *{{.KindLower}}sv1alpha1.ProviderConfig { return &{{.KindLower}}sv1alpha1.ProviderConfig{} }).
-		ProviderName(providerName).
-		PlatformCluster(platformCluster).
-		UpdateChannel(providerConfigUpdates).
-		MustBuild()
-	if err := pcr.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ProviderConfig")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Updates the provider setup to use [opencontrolplane-runtime v1](https://github.com/openmcp-project/opencontrolplane-runtime/releases/tag/v1.0.0).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
use opencontrolplane-runtime v1
```
