### PR TITLE
feat: localaccess with workload cluster

### DIFF
--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -394,7 +394,11 @@ func main() {
 
 	clusterAccessReconciler := advanced.NewClusterAccessReconciler(platformCluster.Client(), providerName)
 	if debugEnabled() {
+		{{- if .WithWorkloadCluster }}
+		clusterAccessReconciler = localaccess.NewLocalAdvancedClusterAccessReconciler(clusterAccessReconciler, localaccess.WithWorkloadCluster())
+		{{- else }}
 		clusterAccessReconciler = localaccess.NewLocalAdvancedClusterAccessReconciler(clusterAccessReconciler)
+		{{- end }}
 	}
 
 	clusterAccessReconciler.


### PR DESCRIPTION
On-behalf-of: @SAP nico.andres@sap.com

**What this PR does / why we need it**:
Makes sure that LocalAdvancedClusterAccessReconciler gets set up with WithWorkloadCluster if a workload cluster is used
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Template now supports local debugging when using a workload cluster
```
