### PR TITLE
fix: setup manager with provider name

### DIFF
--- a/cmd/template/files/main.go.tmpl
+++ b/cmd/template/files/main.go.tmpl
@@ -430,7 +430,7 @@ func main() {
 		}).
 		AdvancedClusterAccessReconciler(clusterAccessReconciler).
 		MustBuild()
-	if err := spr.SetupWithManager(mgr, "{{.KindLower}}"); err != nil {
+	if err := spr.SetupWithManager(mgr, providerName); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "{{.Kind}}")
 		os.Exit(1)
 	}


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Fixes provider config name coupling to hard coded provider name.

**Which issue(s) this PR fixes**:
Fixes the hard coded provider name, see https://github.com/openmcp-project/service-provider-external-secrets/pull/110

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
