### PR TITLE
fix: leader election id

### DIFF
--- a/cmd/service-provider-template/main.go
+++ b/cmd/service-provider-template/main.go
@@ -319,7 +319,8 @@ func main() {
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "{{.GroupSuffix}}.{{.KindLower}}",
+		// opencontrolplane-gen:replace github.com/openmcp-project/service-provider-template=MODULE
+		LeaderElectionID: "github.com/openmcp-project/service-provider-template",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -450,7 +451,8 @@ func main() {
 		AdvancedClusterAccessReconciler(clusterAccessReconciler).
 		MustBuild()
 	if err := spr.SetupWithManager(mgr, providerName); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "{{.Kind}}")
+		// opencontrolplane-gen:replace foo=PROVIDER_NAME
+		setupLog.Error(err, "unable to create controller", "controller", "foo")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
This PR fixes two missed replacements from https://github.com/openmcp-project/service-provider-template/pull/121

**Which issue(s) this PR fixes**:
Replaces the leader election ID placeholder with the user provided module name.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Replace the leader election ID placeholder with the user provided module name.
```
